### PR TITLE
Add some Apple-specific code to allow compilation

### DIFF
--- a/platform_sdl/Renderer.cpp
+++ b/platform_sdl/Renderer.cpp
@@ -3,7 +3,11 @@
 #endif
 #include <SDL.h>
 #include <GLee.h>
+#ifdef __APPLE__
+#include <OpenGL/glu.h>
+#else
 #include <GL/glu.h>
+#endif
 #include "../Renderer.h"
 
 #define STBI_HEADER_FILE_ONLY

--- a/platform_x11/Timer.cpp
+++ b/platform_x11/Timer.cpp
@@ -1,5 +1,22 @@
 #include <time.h>
 
+#ifdef __MACH__
+#include <mach/clock.h>
+#include <mach/mach.h>
+#define CLOCK_MONOTONIC (0)
+// clock_gettime is not implemented on OSX
+int clock_gettime(int /*clk_id*/, struct timespec* ts) {
+  clock_serv_t cclock;
+  mach_timespec_t mts;
+  host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &cclock);
+  clock_get_time(cclock, &mts);
+  mach_port_deallocate(mach_task_self(), cclock);
+  ts->tv_sec = mts.tv_sec;
+  ts->tv_nsec = mts.tv_nsec;
+  return 0;
+}
+#endif
+
 namespace Timer
 {
   timespec startTime;


### PR DESCRIPTION
Some changes are needed to compile on at least OSX 10.8.5. There are some Makefile changes required to build with the existing Makefile, but, those will go into another PR.

- clock_gettime() doesn't exist in MACH, so use the clock_get_time()
- nullptr_t is not declared in older stdc++ for jsonxx
- OpenGL libraries on OSX are located in OpenGL/*