### PR TITLE
Added dummy midi and misc-functions to platform_sdl, fixing linux build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,8 @@ SOURCES_CPP := \
 	Platform.cpp \
 	ShaderEditor.cpp \
 	platform_sdl/Renderer.cpp \
+	platform_sdl/MIDI.cpp \
+	platform_sdl/Misc.cpp \
 	platform_x11/Clipboard.cpp \
 	platform_x11/FFT.cpp \
 	platform_x11/SetupDialog.cpp \
@@ -167,7 +169,7 @@ INCLUDEPATHS := \
 CXX ?= cpp
 OBJDIR ?= .obj
 
-CXXFLAGS := -std=c++11 -Os -Wall -DSCI_LEXER -DSCI_NAMESPACE -DGTK `pkg-config --cflags sdl`
+CXXFLAGS := -std=c++11 -g -Os -Wall -DSCI_LEXER -DSCI_NAMESPACE -DGTK `pkg-config --cflags sdl`
 CXXFLAGS += $(foreach p,$(INCLUDEPATHS),$(addprefix -I,$p))
 #CXXFLAGS += -Werror
 LDFLAGS := -lGL `pkg-config --libs sdl`

--- a/platform_sdl/MIDI.cpp
+++ b/platform_sdl/MIDI.cpp
@@ -1,0 +1,14 @@
+// Dummy midi implementation, just to make sure bonzomatic compiles.
+#include "../MIDI.h"
+
+bool MIDI::Open() {
+	return false;
+}
+
+bool MIDI::Close() {
+	return false;
+}
+
+float MIDI::GetCCValue( unsigned char cc) {
+	return 0.f;
+}

--- a/platform_sdl/Misc.cpp
+++ b/platform_sdl/Misc.cpp
@@ -1,0 +1,13 @@
+// Dummy Keymap functions that don't actually map anything,
+// just to fix the SDL build.
+
+#include <string.h>
+#include "../Misc.h"
+
+void Misc::InitKeymaps() {
+	return;
+}
+
+void Misc::GetKeymapName(char* sz) {
+	strncpy(sz,"<native>",7);
+}


### PR DESCRIPTION
This basically only adds files in platform_sdl, so it should not affect builds on other platforms.
Of course, a working midi implementation on linux would be nice, but a dummy is still better than not compiling at all.