### PR TITLE
Add Ctrl/Cmd-f to hide shader overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The tool was originally conceived and implemented after the Revision 2014 demosc
 ## Keys
 - F2: toggle texture preview
 - F5 or Ctrl-R: recompile shader
-- F11: hide shader overlay
+- F11 or Ctrl/Cmd-f: hide shader overlay
 - Alt-F4: exbobolate your planet
 
 ## Configuration

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -332,7 +332,7 @@ int main()
           mDebugOutput.SetText( szError );
         }
       }
-      else if (Renderer::keyEventBuffer[i].scanCode == 292) // F11
+      else if (Renderer::keyEventBuffer[i].scanCode == 292 || (Renderer::keyEventBuffer[i].ctrl && Renderer::keyEventBuffer[i].scanCode == 'f')) // F11 or Ctrl/Cmd-f  
       {
         bShowGui = !bShowGui;
       }


### PR DESCRIPTION
to resolve problems with using F11 on Mac
