### PR TITLE
Change Linux font path if required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,19 +12,6 @@ set(VERSION_MINOR "0")
 set(VERSION_PATCH "0")
 
 
-
-if (UNIX)
-  set(LINUX_FONT_FILE "/usr/share/fonts/corefonts/cour.ttf")
-  file(GLOB linux_has_font ${LINUX_FONT_FILE})
-  if(linux_has_font MATCHES "^$")
-    set(LINUX_FONT_FILE "/usr/share/fonts/truetype/msttcorefonts/cour.ttf")
-  endif()
-  message("\tUse ${LINUX_FONT_FILE}")
-
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DLINUX_FONT_FILE='\"${LINUX_FONT_FILE}\"'")
-endif(UNIX)
-
-
 option(BONZOMATIC_64BIT "Compile for 64 bit target?" ON)
 if (MSVC)
   if (CMAKE_GENERATOR MATCHES "64")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,20 @@ set(VERSION_MAJOR "1")
 set(VERSION_MINOR "0")
 set(VERSION_PATCH "0")
 
+
+
+if (UNIX)
+  set(LINUX_FONT_FILE "/usr/share/fonts/corefonts/cour.ttf")
+  file(GLOB linux_has_font ${LINUX_FONT_FILE})
+  if(linux_has_font MATCHES "^$")
+    set(LINUX_FONT_FILE "/usr/share/fonts/truetype/msttcorefonts/cour.ttf")
+  endif()
+  message("\tUse ${LINUX_FONT_FILE}")
+
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DLINUX_FONT_FILE='\"${LINUX_FONT_FILE}\"'")
+endif(UNIX)
+
+
 option(BONZOMATIC_64BIT "Compile for 64 bit target?" ON)
 if (MSVC)
   if (CMAKE_GENERATOR MATCHES "64")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -117,7 +117,7 @@ int main()
 #elif __APPLE__
   options.sFontPath = "/Library/Fonts/Courier New.ttf";
 #else
-  options.sFontPath = "/usr/share/fonts/corefonts/cour.ttf";
+  options.sFontPath = LINUX_FONT_FILE;
 #endif
   options.nOpacity = 0xC0;
   options.bUseSpacesForTabs = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,14 +2,8 @@
 #include <string.h>
 #include <assert.h>
 
-// there must be a better way to detext Linux ...
-#ifndef __APPLE__
-#ifndef WIN32
-#ifndef BONZOMATIC_64BIT
-#include <fstream>
-#endif
-#endif
-#endif
+// Needed to test file existence
+#include <unistd.h>
 
 #include "ShaderEditor.h"
 #include "Renderer.h"
@@ -135,7 +129,8 @@ int main()
   int step = 0;
   while(step <2 && options.sFontPath.size() ==0) {
     const std::string & current = fontPaths[step++];
-    if (std::ifstream(current.c_str()).good()) {
+
+    if (access(current.c_str(), R_OK) != -1) {
       options.sFontPath = current;
     }
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,14 @@
 #include <string.h>
 #include <assert.h>
 
+// there must be a better way to detext Linux ...
+#ifndef __APPLE__
+#ifndef WIN32
+#include <array>
+#include <fstream>
+#endif
+#endif
+
 #include "ShaderEditor.h"
 #include "Renderer.h"
 #include "FFT.h"
@@ -117,7 +125,20 @@ int main()
 #elif __APPLE__
   options.sFontPath = "/Library/Fonts/Courier New.ttf";
 #else
-  options.sFontPath = LINUX_FONT_FILE;
+  // Linux case
+  const std::array<std::string, 2> fontPaths = {
+    "/usr/share/fonts/corefonts/cour.ttf",
+    "/usr/share/fonts/truetype/msttcorefonts/cour.ttf"
+  };
+  options.sFontPath = "";
+  for(const std::string & current: fontPaths) {
+    if (std::ifstream(current).good()) {
+      options.sFontPath = current;
+      break;
+    }
+  }
+  assert(options.sFontPath.size()>0 );
+
 #endif
   options.nOpacity = 0xC0;
   options.bUseSpacesForTabs = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,8 +5,10 @@
 // there must be a better way to detext Linux ...
 #ifndef __APPLE__
 #ifndef WIN32
+#ifndef BONZOMATIC_64BIT
 #include <array>
 #include <fstream>
+#endif
 #endif
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,6 @@
 #ifndef __APPLE__
 #ifndef WIN32
 #ifndef BONZOMATIC_64BIT
-#include <array>
 #include <fstream>
 #endif
 #endif
@@ -128,15 +127,16 @@ int main()
   options.sFontPath = "/Library/Fonts/Courier New.ttf";
 #else
   // Linux case
-  const std::array<std::string, 2> fontPaths = {
+  const std::string fontPaths[2] = {
     "/usr/share/fonts/corefonts/cour.ttf",
     "/usr/share/fonts/truetype/msttcorefonts/cour.ttf"
   };
   options.sFontPath = "";
-  for(const std::string & current: fontPaths) {
+  int step = 0;
+  while(step <2 && options.sFontPath.size() ==0) {
+    const std::string & current = fontPaths[step++];
     if (std::ifstream(current).good()) {
       options.sFontPath = current;
-      break;
     }
   }
   assert(options.sFontPath.size()>0 );

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -135,7 +135,7 @@ int main()
   int step = 0;
   while(step <2 && options.sFontPath.size() ==0) {
     const std::string & current = fontPaths[step++];
-    if (std::ifstream(current).good()) {
+    if (std::ifstream(current.c_str()).good()) {
       options.sFontPath = current;
     }
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,8 +2,7 @@
 #include <string.h>
 #include <assert.h>
 
-// Needed to test file existence
-#include <unistd.h>
+
 
 #include "ShaderEditor.h"
 #include "Renderer.h"
@@ -17,6 +16,8 @@
 
 #ifdef WIN32
 #include <windows.h>
+#else
+#include <unistd.h>
 #endif
 
 void ReplaceTokens( std::string &sDefShader, const char * sTokenBegin, const char * sTokenName, const char * sTokenEnd, std::vector<std::string> &tokens )


### PR DESCRIPTION
Under Linux, Bonzomatic wants to use the following font `/usr/share/fonts/corefonts/cour.ttf`.
It seems its installation path depends in not stable over distributions/versions.
This patch use the font `/usr/share/fonts/truetype/msttcorefonts/cour.ttf` if the initial one does not exist