### PR TITLE
Add clipboard support for X11

### DIFF
--- a/src/platform_x11/Clipboard.cpp
+++ b/src/platform_x11/Clipboard.cpp
@@ -1,22 +1,29 @@
-#include <iostream>
+#define GLFW_INCLUDE_NONE
+#include "GLFW/glfw3.h"
+
+#include <string>
+#include <string.h>
 
 namespace Clipboard
 {
   void Copy( const char * data, int len )
   {
-    std::cerr << __FUNCTION__ << " NOT IMPLEMENTED" << std::endl;
+    const std::string contents(data, len);
+    GLFWwindow* window = glfwGetCurrentContext();
+    glfwSetClipboardString(window, contents.c_str());
   }
 
   int GetContentsLength()
   {
-    std::cerr << __FUNCTION__ << " NOT IMPLEMENTED" << std::endl;
-    return 0;
+    GLFWwindow* window = glfwGetCurrentContext();
+    const char* contents = glfwGetClipboardString(window);
+    return strlen(contents);
   }
 
   void GetContents( char * data, int len )
   {
-    std::cerr << __FUNCTION__ << " NOT IMPLEMENTED" << std::endl;
-    data[0] = 0;
+    GLFWwindow* window = glfwGetCurrentContext();
+    const char* contents = glfwGetClipboardString(window);
+    strncpy(data, contents, len);
   }
-
 }


### PR DESCRIPTION
This commit adds clipboard support on X11 platforms via GLFW.

Note that since the clipboard implementation is purely based on GLFW, it may make sense to move it under platform_glfw instead, and have the MacOS X platform also use this (as well as possibly the Windows / GLFW platform). As I don't have access to the corresponding development environments, I kept the amount of changes as small as possible and focused on X11 instead.