### PR TITLE
Configurable width / height / fullscreen mode for GLFW platforms

### DIFF
--- a/src/Capture.h
+++ b/src/Capture.h
@@ -14,8 +14,8 @@ typedef struct
 
 namespace Capture
 {
-  void LoadSettings(jsonxx::Object & o);
-  bool Open(RENDERER_SETTINGS & settings);
+  void ApplySettings(const CAPTURE_SETTINGS & settings);
+  bool Open(const RENDERER_SETTINGS & rendererSettings);
   void CaptureFrame();
   void Close();
 }

--- a/src/Capture.h
+++ b/src/Capture.h
@@ -1,3 +1,14 @@
+#include <string>
+
+typedef struct
+{
+  bool bNDIEnabled;
+  std::string sNDIConnectionString;
+  std::string sNDIIdentifier;
+  float fNDIFrameRate;
+  bool bNDIProgressive;
+} CAPTURE_SETTINGS;
+
 namespace Capture
 {
   void LoadSettings(jsonxx::Object & o);

--- a/src/Capture.h
+++ b/src/Capture.h
@@ -1,3 +1,6 @@
+#ifndef CAPTURE_H
+#define CAPTURE_H
+
 #include <string>
 
 typedef struct
@@ -16,3 +19,5 @@ namespace Capture
   void CaptureFrame();
   void Close();
 }
+
+#endif // CAPTURE_H

--- a/src/Capture.h
+++ b/src/Capture.h
@@ -3,14 +3,15 @@
 
 #include <string>
 
-typedef struct
-{
+struct CAPTURE_SETTINGS {
   bool bNDIEnabled;
   std::string sNDIConnectionString;
   std::string sNDIIdentifier;
   float fNDIFrameRate;
   bool bNDIProgressive;
-} CAPTURE_SETTINGS;
+};
+
+struct RENDERER_SETTINGS;
 
 namespace Capture
 {

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -23,7 +23,7 @@ namespace Renderer
   extern int nHeight;
 
   bool OpenSetupDialog( RENDERER_SETTINGS * settings );
-  bool Open( RENDERER_SETTINGS * settings );
+  bool Open( const RENDERER_SETTINGS & settings );
   
   void StartFrame();
   void EndFrame();

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -1,3 +1,6 @@
+#ifndef RENDERER_H
+#define RENDERER_H
+
 #include <Platform.h>
 
 typedef enum {
@@ -108,3 +111,5 @@ namespace Renderer
   extern MouseEvent mouseEventBuffer[512];
   extern int mouseEventBufferCount;
 }
+
+#endif // RENDERER_H

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -16,7 +16,7 @@ typedef struct
 
 namespace Renderer
 {
-  extern char * defaultShaderFilename;
+  extern const char * defaultShaderFilename;
   extern char defaultShader[65536];
 
   extern int nWidth;
@@ -31,9 +31,9 @@ namespace Renderer
 
   void RenderFullscreenQuad();
 
-  bool ReloadShader( char * szShaderCode, int nShaderCodeSize, char * szErrorBuffer, int nErrorBufferSize );
-  void SetShaderConstant( char * szConstName, float x );
-  void SetShaderConstant( char * szConstName, float x, float y );
+  bool ReloadShader( const char * szShaderCode, int nShaderCodeSize, char * szErrorBuffer, int nErrorBufferSize );
+  void SetShaderConstant( const char * szConstName, float x );
+  void SetShaderConstant( const char * szConstName, float x, float y );
 
   void StartTextRendering();
   void SetTextRenderingViewport( Scintilla::PRectangle rect );
@@ -56,11 +56,11 @@ namespace Renderer
     TEXTURETYPE type;
   };
 
-  Texture * CreateRGBA8TextureFromFile( char * szFilename );
+  Texture * CreateRGBA8TextureFromFile( const char * szFilename );
   Texture * CreateA8TextureFromData( int w, int h, unsigned char * data );
   Texture * Create1DR32Texture( int w );
   bool UpdateR32Texture( Texture * tex, float * data );
-  void SetShaderTexture( char * szTextureName, Texture * tex );
+  void SetShaderTexture( const char * szTextureName, Texture * tex );
   void BindTexture( Texture * tex ); // temporary function until all the quad rendering is moved to the renderer
   void ReleaseTexture( Texture * tex );
   struct Vertex

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -9,13 +9,12 @@ typedef enum {
   RENDERER_WINDOWMODE_BORDERLESS
 } RENDERER_WINDOWMODE;
 
-typedef struct 
-{
+struct RENDERER_SETTINGS {
   int nWidth;
   int nHeight;
   RENDERER_WINDOWMODE windowMode;
   bool bVsync;
-} RENDERER_SETTINGS;
+};
 
 namespace Renderer
 {

--- a/src/capturing/Capture_Dummy.cpp
+++ b/src/capturing/Capture_Dummy.cpp
@@ -1,12 +1,12 @@
-#include "jsonxx.h"
+#include "Capture.h"
 #include "Renderer.h"
 
 namespace Capture
 {
-  void LoadSettings(jsonxx::Object & o)
+  void ApplySettings(const CAPTURE_SETTINGS & settings)
   {
   }
-  bool Open(RENDERER_SETTINGS & settings)
+  bool Open(const RENDERER_SETTINGS & rendererSettings)
   {
     return true;
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -89,7 +89,7 @@ int main()
     return -1;
 #endif
 
-  if (!Renderer::Open( &settings ))
+  if (!Renderer::Open( settings ))
   {
     printf("Renderer::Open failed\n");
     return -1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -195,7 +195,29 @@ int main()
         midiRoutes.insert( std::make_pair( it->second->number_value_, it->first ) );
       }
     }
-    Capture::LoadSettings( o );
+
+    CAPTURE_SETTINGS captureSettings;
+    captureSettings.bNDIEnabled = true;
+    captureSettings.sNDIConnectionString = "";
+    captureSettings.sNDIIdentifier = "";
+    captureSettings.fNDIFrameRate = 60.0;
+    captureSettings.bNDIProgressive = true;
+
+    if (o.has<jsonxx::Object>("ndi"))
+    {
+      if (o.get<jsonxx::Object>("ndi").has<jsonxx::Boolean>("enabled"))
+        captureSettings.bNDIEnabled = o.get<jsonxx::Object>("ndi").get<jsonxx::Boolean>("enabled");
+      if (o.get<jsonxx::Object>("ndi").has<jsonxx::String>("connectionString"))
+        captureSettings.sNDIConnectionString = o.get<jsonxx::Object>("ndi").get<jsonxx::String>("connectionString");
+      if (o.get<jsonxx::Object>("ndi").has<jsonxx::String>("identifier"))
+        captureSettings.sNDIIdentifier = o.get<jsonxx::Object>("ndi").get<jsonxx::String>("identifier");
+      if (o.get<jsonxx::Object>("ndi").has<jsonxx::Number>("frameRate"))
+        captureSettings.fNDIFrameRate = o.get<jsonxx::Object>("ndi").get<jsonxx::Number>("frameRate");
+      if (o.get<jsonxx::Object>("ndi").has<jsonxx::Boolean>("progressive"))
+        captureSettings.bNDIProgressive = o.get<jsonxx::Object>("ndi").get<jsonxx::Boolean>("progressive");
+    }
+
+    Capture::ApplySettings( captureSettings );
   }
   if ( !Capture::Open( settings ) )
   {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -231,6 +231,8 @@ int main()
 #endif
 
   SETTINGS settings;
+  LoadSettings( &settings );
+
   RENDERER_SETTINGS& rendererSettings = settings.rendererSettings;
 
 #ifndef _DEBUG
@@ -255,8 +257,6 @@ int main()
     printf("MIDI::Open() failed, continuing anyway...\n");
     //return -1;
   }
-
-  LoadSettings( &settings );
 
   const CAPTURE_SETTINGS& captureSettings = settings.captureSettings;
   Capture::ApplySettings( captureSettings );

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -133,7 +133,7 @@ void SETTINGS::ApplyDefaults()
   fFFTSlightSmoothingFactor = 0.6f; // higher value, smoother FFT
 }
 
-void LoadConfiguration(SETTINGS * settings)
+void LoadSettings(SETTINGS * settings)
 {
   char szConfig[65535];
   FILE * fConf = fopen("config.json","rb");
@@ -152,6 +152,14 @@ void LoadConfiguration(SETTINGS * settings)
 
   if (o.has<jsonxx::Object>("rendering"))
   {
+    RENDERER_SETTINGS& rendererSettings = settings->rendererSettings;
+
+    if (o.get<jsonxx::Object>("rendering").has<jsonxx::Number>("width"))
+      rendererSettings.nWidth = o.get<jsonxx::Object>("rendering").get<jsonxx::Number>("width");
+    if (o.get<jsonxx::Object>("rendering").has<jsonxx::Number>("height"))
+      rendererSettings.nHeight = o.get<jsonxx::Object>("rendering").get<jsonxx::Number>("height");
+    if (o.get<jsonxx::Object>("rendering").has<jsonxx::Boolean>("fullscreen"))
+      rendererSettings.windowMode = o.get<jsonxx::Object>("rendering").get<jsonxx::Boolean>("fullscreen") ? RENDERER_WINDOWMODE_FULLSCREEN : RENDERER_WINDOWMODE_WINDOWED;
     if (o.get<jsonxx::Object>("rendering").has<jsonxx::Number>("fftSmoothFactor"))
       settings->fFFTSmoothingFactor = o.get<jsonxx::Object>("rendering").get<jsonxx::Number>("fftSmoothFactor");
   }
@@ -248,7 +256,7 @@ int main()
     //return -1;
   }
 
-  LoadConfiguration( &settings );
+  LoadSettings( &settings );
 
   const CAPTURE_SETTINGS& captureSettings = settings.captureSettings;
   Capture::ApplySettings( captureSettings );

--- a/src/platform_glfw/Renderer.cpp
+++ b/src/platform_glfw/Renderer.cpp
@@ -270,7 +270,7 @@ namespace Renderer
     glGenBuffers( 1, &glhFullscreenQuadVB );
     glBindBuffer( GL_ARRAY_BUFFER, glhFullscreenQuadVB );
     glBufferData( GL_ARRAY_BUFFER, sizeof(float) * 5 * 4, pFullscreenQuadVertices, GL_STATIC_DRAW );
-    glBindBuffer( GL_ARRAY_BUFFER, NULL );
+    glBindBuffer( GL_ARRAY_BUFFER, 0 );
 
     glGenVertexArrays(1, &glhFullscreenQuadVA);
 
@@ -386,7 +386,7 @@ namespace Renderer
     glBindBuffer(GL_PIXEL_PACK_BUFFER, pbo[1]);
     glBufferData(GL_PIXEL_PACK_BUFFER, settings->nWidth * settings->nHeight * sizeof(unsigned int), NULL, GL_STREAM_READ);
     //unbind buffers for now
-    glBindBuffer(GL_PIXEL_PACK_BUFFER, NULL);
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
 
     run = true;
 
@@ -564,7 +564,7 @@ namespace Renderer
     glDisableVertexAttribArray( texcoord );
     glDisableVertexAttribArray( position );
 
-    glUseProgram(NULL);
+    glUseProgram(0);
   }
 
   bool ReloadShader( const char * szShaderCode, int nShaderCodeSize, char * szErrorBuffer, int nErrorBufferSize )
@@ -903,7 +903,7 @@ namespace Renderer
     glDisableVertexAttribArray( color );
     glDisableVertexAttribArray( position );
 
-    glUseProgram(NULL);
+    glUseProgram(0);
 
     glDisable(GL_BLEND);
     glDisable(GL_SCISSOR_TEST);
@@ -932,7 +932,7 @@ namespace Renderer
       }
       glUnmapBuffer(GL_PIXEL_PACK_BUFFER);
     }
-    glBindBuffer(GL_PIXEL_PACK_BUFFER, NULL);
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
 
     return true;
   }

--- a/src/platform_glfw/Renderer.cpp
+++ b/src/platform_glfw/Renderer.cpp
@@ -192,7 +192,7 @@ namespace Renderer
   void mouse_button_callback(GLFWwindow* window, int button, int action, int mods);
   void scroll_callback(GLFWwindow* window, double xoffset, double yoffset);
 
-  bool Open( RENDERER_SETTINGS * settings )
+  bool Open( const RENDERER_SETTINGS & settings )
   {
     glfwSetErrorCallback(error_callback);
     theShader = 0;
@@ -202,8 +202,8 @@ namespace Renderer
       return false;
     }
 
-    nWidth = settings->nWidth;
-    nHeight = settings->nHeight;
+    nWidth = settings.nWidth;
+    nHeight = settings.nHeight;
 
     glfwWindowHint(GLFW_RED_BITS, 8);
     glfwWindowHint(GLFW_GREEN_BITS, 8);
@@ -222,7 +222,7 @@ namespace Renderer
     // TODO: change in case of resize support
     glfwWindowHint(GLFW_RESIZABLE, GL_FALSE);
 
-    GLFWmonitor *monitor = settings->windowMode == RENDERER_WINDOWMODE_FULLSCREEN ? glfwGetPrimaryMonitor() : NULL;
+    GLFWmonitor *monitor = settings.windowMode == RENDERER_WINDOWMODE_FULLSCREEN ? glfwGetPrimaryMonitor() : NULL;
 
     mWindow = glfwCreateWindow(nWidth, nHeight, "BONZOMATIC - GLFW edition", monitor, NULL);
     if (!mWindow)
@@ -255,7 +255,7 @@ namespace Renderer
     glfwSwapInterval(1);
 
 #ifdef _WIN32
-    if (settings->bVsync)
+    if (settings.bVsync)
       wglSwapIntervalEXT(1);
 #endif
 
@@ -382,9 +382,9 @@ namespace Renderer
     //create PBOs to hold the data. this allocates memory for them too
     glGenBuffers(2, pbo);
     glBindBuffer(GL_PIXEL_PACK_BUFFER, pbo[0]);
-    glBufferData(GL_PIXEL_PACK_BUFFER, settings->nWidth * settings->nHeight * sizeof(unsigned int), NULL, GL_STREAM_READ);
+    glBufferData(GL_PIXEL_PACK_BUFFER, settings.nWidth * settings.nHeight * sizeof(unsigned int), NULL, GL_STREAM_READ);
     glBindBuffer(GL_PIXEL_PACK_BUFFER, pbo[1]);
-    glBufferData(GL_PIXEL_PACK_BUFFER, settings->nWidth * settings->nHeight * sizeof(unsigned int), NULL, GL_STREAM_READ);
+    glBufferData(GL_PIXEL_PACK_BUFFER, settings.nWidth * settings.nHeight * sizeof(unsigned int), NULL, GL_STREAM_READ);
     //unbind buffers for now
     glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
 

--- a/src/platform_glfw/Renderer.cpp
+++ b/src/platform_glfw/Renderer.cpp
@@ -109,7 +109,7 @@ const char * shaderBuiltin =
 
 namespace Renderer
 {
-  char * defaultShaderFilename = "shader.glsl";
+  const char * defaultShaderFilename = "shader.glsl";
   char defaultShader[65536] =
     "#version 410 core\n"
     "\n"
@@ -276,7 +276,7 @@ namespace Renderer
 
     glhVertexShader = glCreateShader( GL_VERTEX_SHADER );
 
-    char * szVertexShader =
+    const char * szVertexShader =
       "#version 410 core\n"
       "in vec3 in_pos;\n"
       "in vec2 in_texcoord;\n"
@@ -304,7 +304,7 @@ namespace Renderer
 
 #define GUIQUADVB_SIZE (1024 * 6)
 
-    char * defaultGUIVertexShader =
+    const char * defaultGUIVertexShader =
       "#version 410 core\n"
       "in vec3 in_pos;\n"
       "in vec4 in_color;\n"
@@ -323,7 +323,7 @@ namespace Renderer
       "  out_texcoord = in_texcoord;\n"
       "  out_factor = in_factor;\n"
       "}\n";
-    char * defaultGUIPixelShader =
+    const char * defaultGUIPixelShader =
       "#version 410 core\n"
       "uniform sampler2D tex;\n"
       "in vec4 out_color;\n"
@@ -567,7 +567,7 @@ namespace Renderer
     glUseProgram(NULL);
   }
 
-  bool ReloadShader( char * szShaderCode, int nShaderCodeSize, char * szErrorBuffer, int nErrorBufferSize )
+  bool ReloadShader( const char * szShaderCode, int nShaderCodeSize, char * szErrorBuffer, int nErrorBufferSize )
   {
     GLuint prg = glCreateProgram();
     GLuint shd = glCreateShader(GL_FRAGMENT_SHADER);
@@ -605,7 +605,7 @@ namespace Renderer
     return true;
   }
 
-  void SetShaderConstant( char * szConstName, float x )
+  void SetShaderConstant( const char * szConstName, float x )
   {
     GLint location = glGetUniformLocation( theShader, szConstName );
     if ( location != -1 )
@@ -614,7 +614,7 @@ namespace Renderer
     }
   }
 
-  void SetShaderConstant( char * szConstName, float x, float y )
+  void SetShaderConstant( const char * szConstName, float x, float y )
   {
     GLint location = glGetUniformLocation( theShader, szConstName );
     if ( location != -1 )
@@ -630,7 +630,7 @@ namespace Renderer
   };
 
   int textureUnit = 0;
-  Texture * CreateRGBA8TextureFromFile( char * szFilename )
+  Texture * CreateRGBA8TextureFromFile( const char * szFilename )
   {
     int comp = 0;
     int width = 0;
@@ -692,7 +692,7 @@ namespace Renderer
     return tex;
   }
 
-  void SetShaderTexture( char * szTextureName, Texture * tex )
+  void SetShaderTexture( const char * szTextureName, Texture * tex )
   {
     if (!tex)
       return;

--- a/src/platform_w32_dx11/Renderer.cpp
+++ b/src/platform_w32_dx11/Renderer.cpp
@@ -320,7 +320,7 @@ namespace Renderer
     return DefWindowProc(hWnd, uMsg, wParam, lParam);
   }
 
-  bool InitWindow(RENDERER_SETTINGS * pSetup) 
+  bool InitWindow(const RENDERER_SETTINGS & pSetup)
   {
     WNDCLASS WC;
 
@@ -339,14 +339,14 @@ namespace Renderer
 
     DWORD wExStyle = WS_EX_APPWINDOW;
     DWORD wStyle = WS_POPUP | WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
-    if (pSetup->windowMode == RENDERER_WINDOWMODE_WINDOWED) wStyle |= WS_OVERLAPPED | WS_CAPTION;
+    if (pSetup.windowMode == RENDERER_WINDOWMODE_WINDOWED) wStyle |= WS_OVERLAPPED | WS_CAPTION;
 
-    RECT wr={0,0,pSetup->nWidth,pSetup->nHeight};
+    RECT wr={0,0,pSetup.nWidth,pSetup.nHeight};
     AdjustWindowRectEx(&wr, wStyle, FALSE, wExStyle);
 
     hWnd = CreateWindowEx(wExStyle,_T("fwzwnd"),_T("BONZOMATIC - Direct3D 11.0 edition"),wStyle,
-      (GetSystemMetrics(SM_CXSCREEN) - pSetup->nWidth )/2,
-      (GetSystemMetrics(SM_CYSCREEN) - pSetup->nHeight)/2,
+      (GetSystemMetrics(SM_CXSCREEN) - pSetup.nWidth )/2,
+      (GetSystemMetrics(SM_CYSCREEN) - pSetup.nHeight)/2,
       wr.right-wr.left, wr.bottom-wr.top,
       NULL, NULL, WC.hInstance, NULL);
 
@@ -361,17 +361,17 @@ namespace Renderer
   }
 
   bool bVsync = false;
-  bool InitDirect3D(RENDERER_SETTINGS * pSetup) 
+  bool InitDirect3D(const RENDERER_SETTINGS & pSetup)
   {
     DXGI_FORMAT format = DXGI_FORMAT_R8G8B8A8_UNORM;
 
     DXGI_SWAP_CHAIN_DESC desc;
     ZeroMemory(&desc, sizeof(DXGI_SWAP_CHAIN_DESC));
     desc.BufferCount = 1;
-    desc.BufferDesc.Width = pSetup->nWidth;
-    desc.BufferDesc.Height = pSetup->nHeight;
+    desc.BufferDesc.Width = pSetup.nWidth;
+    desc.BufferDesc.Height = pSetup.nHeight;
     desc.BufferDesc.Format = format;
-    if (pSetup->bVsync)
+    if (pSetup.bVsync)
     {
       bVsync = true;
       IDXGIFactory1 * pFactory = NULL;
@@ -394,7 +394,7 @@ namespace Renderer
 
             for (int i=0; i<nModeCount; i++)
             {
-              if (pModes[i].Width == pSetup->nWidth && pModes[i].Height == pSetup->nHeight)
+              if (pModes[i].Width == pSetup.nWidth && pModes[i].Height == pSetup.nHeight)
               {
                 desc.BufferDesc = pModes[i];
                 break;
@@ -414,7 +414,7 @@ namespace Renderer
     desc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
     desc.OutputWindow = hWnd;
     desc.SampleDesc.Count = 1;
-    desc.Windowed = pSetup->windowMode != RENDERER_WINDOWMODE_FULLSCREEN;
+    desc.Windowed = pSetup.windowMode != RENDERER_WINDOWMODE_FULLSCREEN;
 
     DWORD deviceCreationFlags = 0;
 #ifdef _DEBUG
@@ -468,7 +468,7 @@ namespace Renderer
   ID3D11BlendState* pFullscreenQuadBlendState = NULL;
   ID3D11RasterizerState * pFullscreenQuadRasterizerState = NULL;
 
-  bool InitD3D11QuadRendering( RENDERER_SETTINGS * settings )
+  bool InitD3D11QuadRendering( const RENDERER_SETTINGS & settings )
   {
     ID3DBlob * pCode = NULL;
     ID3DBlob * pErrors = NULL;
@@ -529,8 +529,8 @@ namespace Renderer
 
     viewport.TopLeftX = 0;
     viewport.TopLeftY = 0;
-    viewport.Width  = settings->nWidth;
-    viewport.Height = settings->nHeight;
+    viewport.Width  = settings.nWidth;
+    viewport.Height = settings.nHeight;
 
     pContext->RSSetViewports(1, &viewport);
 
@@ -621,7 +621,7 @@ namespace Renderer
     pout[3 + 3 * 4] = 1.0;
   }
 
-  bool InitD3D11GUIRendering( RENDERER_SETTINGS * settings )
+  bool InitD3D11GUIRendering( const RENDERER_SETTINGS & settings )
   {
     ID3DBlob * pCode = NULL;
     ID3DBlob * pErrors = NULL;
@@ -711,10 +711,10 @@ namespace Renderer
     return true;
   }
 
-  bool Open( RENDERER_SETTINGS * settings )
+  bool Open( const RENDERER_SETTINGS & settings )
   {
-    nWidth  = settings->nWidth;
-    nHeight = settings->nHeight;
+    nWidth  = settings.nWidth;
+    nHeight = settings.nHeight;
 
     if (!InitWindow(settings))
     {

--- a/src/platform_w32_dx11/Renderer.cpp
+++ b/src/platform_w32_dx11/Renderer.cpp
@@ -100,7 +100,7 @@ const char * shaderBuiltin =
 
 namespace Renderer
 {
-  char * defaultShaderFilename = "shader.dx11.hlsl";
+  const char * defaultShaderFilename = "shader.dx11.hlsl";
   char defaultShader[65536] = 
     "{%textures:begin%}" // leave off \n here
     "Texture2D {%textures:name%};\n"
@@ -819,7 +819,7 @@ namespace Renderer
   }
 
   ID3D11ShaderReflectionConstantBuffer * pCBuf = NULL;
-  bool ReloadShader( char * szShaderCode, int nShaderCodeSize, char * szErrorBuffer, int nErrorBufferSize )
+  bool ReloadShader( const char * szShaderCode, int nShaderCodeSize, char * szErrorBuffer, int nErrorBufferSize )
   {
     ID3DBlob * pCode = NULL;
     ID3DBlob * pErrors = NULL;
@@ -854,7 +854,7 @@ namespace Renderer
     pContext->Unmap( pFullscreenQuadConstantBuffer, NULL );
   }
 
-  void SetShaderConstant( char * szConstName, float x )
+  void SetShaderConstant( const char * szConstName, float x )
   {
     ID3D11ShaderReflectionVariable * pCVar = pCBuf->GetVariableByName( szConstName );
     D3D11_SHADER_VARIABLE_DESC pDesc;
@@ -866,7 +866,7 @@ namespace Renderer
     __UpdateConstants();
   }
 
-  void SetShaderConstant( char * szConstName, float x, float y )
+  void SetShaderConstant( const char * szConstName, float x, float y )
   {
     ID3D11ShaderReflectionVariable * pCVar = pCBuf->GetVariableByName(szConstName);
     D3D11_SHADER_VARIABLE_DESC pDesc;
@@ -907,7 +907,7 @@ namespace Renderer
   }
 
   int textureUnit = 0;
-  Texture * CreateRGBA8TextureFromFile( char * szFilename )
+  Texture * CreateRGBA8TextureFromFile( const char * szFilename )
   {
     int comp = 0;
     int width = 0;
@@ -974,7 +974,7 @@ namespace Renderer
     return tex;
   }
 
-  void SetShaderTexture( char * szTextureName, Texture * tex )
+  void SetShaderTexture( const char * szTextureName, Texture * tex )
   {
     D3D11_SHADER_INPUT_BIND_DESC desc;
     if (pShaderReflection->GetResourceBindingDescByName( szTextureName, &desc ) == S_OK)

--- a/src/platform_w32_dx9/Renderer.cpp
+++ b/src/platform_w32_dx9/Renderer.cpp
@@ -316,7 +316,7 @@ namespace Renderer
     return DefWindowProc(hWnd, uMsg, wParam, lParam);
   }
 
-  bool InitWindow(RENDERER_SETTINGS * pSetup) 
+  bool InitWindow(const RENDERER_SETTINGS & pSetup)
   {
     WNDCLASS WC;
 
@@ -335,14 +335,14 @@ namespace Renderer
 
     DWORD wExStyle = WS_EX_APPWINDOW;
     DWORD wStyle = WS_POPUP | WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
-    if (pSetup->windowMode == RENDERER_WINDOWMODE_WINDOWED) wStyle |= WS_OVERLAPPED | WS_CAPTION;
+    if (pSetup.windowMode == RENDERER_WINDOWMODE_WINDOWED) wStyle |= WS_OVERLAPPED | WS_CAPTION;
 
-    RECT wr={0,0,pSetup->nWidth,pSetup->nHeight};
+    RECT wr={0,0,pSetup.nWidth,pSetup.nHeight};
     AdjustWindowRectEx(&wr, wStyle, FALSE, wExStyle);
 
     hWnd = CreateWindowEx(wExStyle,_T("fwzwnd"),_T("BONZOMATIC - Direct3D 9.0c edition"),wStyle,
-      (GetSystemMetrics(SM_CXSCREEN) - pSetup->nWidth )/2,
-      (GetSystemMetrics(SM_CYSCREEN) - pSetup->nHeight)/2,
+      (GetSystemMetrics(SM_CXSCREEN) - pSetup.nWidth )/2,
+      (GetSystemMetrics(SM_CYSCREEN) - pSetup.nHeight)/2,
       wr.right-wr.left, wr.bottom-wr.top,
       NULL, NULL, WC.hInstance, NULL);
 
@@ -357,7 +357,7 @@ namespace Renderer
   }
 
   D3DPRESENT_PARAMETERS d3dpp;
-  bool InitDirect3D(RENDERER_SETTINGS * pSetup) 
+  bool InitDirect3D(const RENDERER_SETTINGS & pSetup)
   {
     pD3D = Direct3DCreate9(D3D9b_SDK_VERSION);
     if (!pD3D) 
@@ -366,20 +366,20 @@ namespace Renderer
       return false;
     }
 
-    nWidth  = pSetup->nWidth;
-    nHeight = pSetup->nHeight;
+    nWidth  = pSetup.nWidth;
+    nHeight = pSetup.nHeight;
 
     ZeroMemory(&d3dpp,sizeof(d3dpp));
 
     d3dpp.SwapEffect     = D3DSWAPEFFECT_DISCARD;
     d3dpp.hDeviceWindow  = hWnd;
-    d3dpp.Windowed       = pSetup->windowMode != RENDERER_WINDOWMODE_FULLSCREEN;
-    d3dpp.PresentationInterval = pSetup->bVsync ? D3DPRESENT_INTERVAL_ONE : D3DPRESENT_INTERVAL_IMMEDIATE;
+    d3dpp.Windowed       = pSetup.windowMode != RENDERER_WINDOWMODE_FULLSCREEN;
+    d3dpp.PresentationInterval = pSetup.bVsync ? D3DPRESENT_INTERVAL_ONE : D3DPRESENT_INTERVAL_IMMEDIATE;
 
     d3dpp.BackBufferCount  = 1;
 
-    d3dpp.BackBufferWidth  = pSetup->nWidth;
-    d3dpp.BackBufferHeight = pSetup->nHeight;
+    d3dpp.BackBufferWidth  = pSetup.nWidth;
+    d3dpp.BackBufferHeight = pSetup.nHeight;
 
     D3DDISPLAYMODE d3ddm;
     if( FAILED( pD3D->GetAdapterDisplayMode( D3DADAPTER_DEFAULT, &d3ddm ) ) )
@@ -449,7 +449,7 @@ namespace Renderer
 
 #define GUIQUADVB_SIZE (128*6)
 
-  bool Open( RENDERER_SETTINGS * settings )
+  bool Open( const RENDERER_SETTINGS & settings )
   {
     if (!InitWindow(settings))
     {
@@ -506,7 +506,7 @@ namespace Renderer
       return false;
     }
 
-    if (pDevice->CreateOffscreenPlainSurface( settings->nWidth, settings->nHeight, d3dpp.BackBufferFormat, D3DPOOL_SYSTEMMEM, &pFrameGrabTexture, NULL) != D3D_OK)
+    if (pDevice->CreateOffscreenPlainSurface( settings.nWidth, settings.nHeight, d3dpp.BackBufferFormat, D3DPOOL_SYSTEMMEM, &pFrameGrabTexture, NULL) != D3D_OK)
     {
       printf("[Renderer] CreateOffscreenPlainSurface failed\n");
       return false;

--- a/src/platform_w32_dx9/Renderer.cpp
+++ b/src/platform_w32_dx9/Renderer.cpp
@@ -99,7 +99,7 @@ const char * shaderBuiltin =
 
 namespace Renderer
 {
-  char * defaultShaderFilename = "shader.dx9.hlsl";
+  const char * defaultShaderFilename = "shader.dx9.hlsl";
   char defaultShader[65536] = 
     "texture texTFFT; sampler1D texFFT = sampler_state { Texture = <texTFFT>; }; \n"
     "// towards 0.0 is bass / lower freq, towards 1.0 is higher / treble freq\n"
@@ -566,7 +566,7 @@ namespace Renderer
     pDevice->DrawPrimitive( D3DPT_TRIANGLESTRIP, 0, 2 );
   }
 
-  bool ReloadShader( char * szShaderCode, int nShaderCodeSize, char * szErrorBuffer, int nErrorBufferSize )
+  bool ReloadShader( const char * szShaderCode, int nShaderCodeSize, char * szErrorBuffer, int nErrorBufferSize )
   {
     LPD3DXBUFFER pShader = NULL;
     LPD3DXBUFFER pErrors = NULL;
@@ -592,12 +592,12 @@ namespace Renderer
     return true;
   }
 
-  void SetShaderConstant( char * szConstName, float x )
+  void SetShaderConstant( const char * szConstName, float x )
   {
     pConstantTable->SetFloat( pDevice, szConstName, x );
   }
 
-  void SetShaderConstant( char * szConstName, float x, float y )
+  void SetShaderConstant( const char * szConstName, float x, float y )
   {
     pConstantTable->SetVector( pDevice, szConstName, &D3DXVECTOR4(x, y, 0, 0) );
   }
@@ -608,7 +608,7 @@ namespace Renderer
   };
 
   int textureUnit = 0;
-  Texture * CreateRGBA8TextureFromFile( char * szFilename )
+  Texture * CreateRGBA8TextureFromFile( const char * szFilename )
   {
     LPDIRECT3DTEXTURE9 pTex = NULL;
     D3DXIMAGE_INFO info;
@@ -660,7 +660,7 @@ namespace Renderer
     return tex;
   }
 
-  void SetShaderTexture( char * szTextureName, Texture * tex )
+  void SetShaderTexture( const char * szTextureName, Texture * tex )
   {
     int idx = pConstantTable->GetSamplerIndex( szTextureName );
     if (idx >= 0)

--- a/src/platform_x11/SetupDialog.cpp
+++ b/src/platform_x11/SetupDialog.cpp
@@ -3,9 +3,5 @@
 
 bool Renderer::OpenSetupDialog( RENDERER_SETTINGS * settings )
 {
-  std::cerr << __FUNCTION__ << " STUB" << std::endl;
-  settings->nWidth = 1280;
-  settings->nHeight = 720;
-  settings->windowMode = RENDERER_WINDOWMODE_WINDOWED;
   return true;
 }


### PR DESCRIPTION
On GLFW platforms (where the setup dialog can not be implemented), the renderer resolution and fullscreen / windowed mode are hardcoded. These changes provide configurable width, height and fullscreen via the JSON configuration file for GLFW platforms. On Windows (where the setup dialog is implemented), the values specified in the configuration file are (for now) overridden by the dialog inputs. To introduce these changes, some refactoring of the settings was required. A few compiler warnings have additionally been fixed.

Here is an overview of the commits:
- Collect the capture settings in a structure,
- Collect all the settings (capture, renderer, shader editor and others) into a single settings structure (initialized with the usual defaults),
- Move all configuration value queries to a single function (especially the ones from Capture) to populate this settings structure,
- Fix various const-correctness issues in the Renderer and Capture interfaces and main code,
- Fix warnings related to using NULL pointers instead of 0 objects for GL calls,
- Add rendering.width, rendering.height and rendering.fullscreen configuration values,
- Query configuration values before initializing the renderer and create textures afterwards.

Disclaimer: changes to the DX9, DX11 and NDI code have not been compiled.
