### PR TITLE
Add resolution dialog for MacOS and misc fullscreen fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,8 +305,8 @@ if (APPLE)
     ${CMAKE_SOURCE_DIR}/src/platform_common/FFT.cpp
     ${CMAKE_SOURCE_DIR}/src/platform_x11/MIDI.cpp
     ${CMAKE_SOURCE_DIR}/src/platform_x11/Misc.cpp
-    ${CMAKE_SOURCE_DIR}/src/platform_x11/SetupDialog.cpp
     ${CMAKE_SOURCE_DIR}/src/platform_x11/Timer.cpp
+    ${CMAKE_SOURCE_DIR}/src/platform_osx/SetupDialog.cpp
     ${CMAKE_SOURCE_DIR}/src/platform_osx/Clipboard.cpp
   )
   source_group("Bonzomatic\\Platform" FILES ${BZC_PLATFORM_SRCS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,13 @@ if (MSVC)
   endif ()
 endif ()
 
+if (APPLE)
+  set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++14")
+  set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
+  set(CMAKE_XCODE_ATTRIBUTE_GCC_ENABLE_CPP_EXCEPTIONS "No")
+  set(CMAKE_XCODE_ATTRIBUTE_GCC_ENABLE_CPP_RTTI "No")
+endif ()
+
 # Dont compile glfw and glew for windows dx targets
 if (APPLE OR UNIX OR (MSVC AND (${BONZOMATIC_WINDOWS_FLAVOR} MATCHES "GLFW")))
   ##############################################################################

--- a/src/platform_glfw/Renderer.cpp
+++ b/src/platform_glfw/Renderer.cpp
@@ -259,6 +259,14 @@ namespace Renderer
       wglSwapIntervalEXT(1);
 #endif
 
+    // Now, since OpenGL is behaving a lot in fullscreen modes, lets collect the real obtained size!
+    int fbWidth = 1;
+    int fbHeight = 1;
+    glfwGetFramebufferSize(mWindow, &fbWidth, &fbHeight);
+    nWidth = settings->nWidth = fbWidth;
+    nHeight = settings->nHeight = fbHeight;
+    printf("[GLFW] Obtained framebuffer size: %d x %d\n", fbWidth, fbHeight);
+    
     static float pFullscreenQuadVertices[] =
     {
       -1.0, -1.0,  0.5, 0.0, 0.0,
@@ -382,12 +390,14 @@ namespace Renderer
     //create PBOs to hold the data. this allocates memory for them too
     glGenBuffers(2, pbo);
     glBindBuffer(GL_PIXEL_PACK_BUFFER, pbo[0]);
-    glBufferData(GL_PIXEL_PACK_BUFFER, settings->nWidth * settings->nHeight * sizeof(unsigned int), NULL, GL_STREAM_READ);
+    glBufferData(GL_PIXEL_PACK_BUFFER, nWidth * nHeight * sizeof(unsigned int), NULL, GL_STREAM_READ);
     glBindBuffer(GL_PIXEL_PACK_BUFFER, pbo[1]);
-    glBufferData(GL_PIXEL_PACK_BUFFER, settings->nWidth * settings->nHeight * sizeof(unsigned int), NULL, GL_STREAM_READ);
+    glBufferData(GL_PIXEL_PACK_BUFFER, nWidth * nHeight * sizeof(unsigned int), NULL, GL_STREAM_READ);
     //unbind buffers for now
     glBindBuffer(GL_PIXEL_PACK_BUFFER, NULL);
 
+    glViewport(0, 0, nWidth, nHeight);
+    
     run = true;
 
     return true;

--- a/src/platform_osx/SetupDialog.cpp
+++ b/src/platform_osx/SetupDialog.cpp
@@ -21,7 +21,7 @@ void BuildListOfMainDisplayResolutions(std::set<Resolution> &resolutions)
   for (CFIndex i = 0;  i < found;  i++)
   {
     CGDisplayModeRef dm = (CGDisplayModeRef) CFArrayGetValueAtIndex(modes, i);
-    resolutions.insert({(int)CGDisplayModeGetWidth(dm), (int)CGDisplayModeGetHeight(dm)});
+    resolutions.insert(Resolution((int)CGDisplayModeGetWidth(dm), (int)CGDisplayModeGetHeight(dm)));
   }
   CFRelease(modes);
 }
@@ -31,10 +31,10 @@ bool Renderer::OpenSetupDialog( RENDERER_SETTINGS * settings )
   std::set<Resolution> resolutions;
   
   // Force some default resolutions
-  resolutions.insert({1280, 720});
-  resolutions.insert({1920, 1080});
+  resolutions.insert(Resolution(1280, 720));
+  resolutions.insert(Resolution(1920, 1080));
   // Also add the resolution found in the settings
-  resolutions.insert({settings->nWidth, settings->nHeight});
+  resolutions.insert(Resolution(settings->nWidth, settings->nHeight));
   
   BuildListOfMainDisplayResolutions(resolutions);
   

--- a/src/platform_osx/SetupDialog.cpp
+++ b/src/platform_osx/SetupDialog.cpp
@@ -1,0 +1,111 @@
+#include <iostream>
+#include "../Renderer.h"
+#include <CoreFoundation/CoreFoundation.h>
+#include <CoreGraphics/CoreGraphics.h>
+#include <set>
+
+struct Resolution
+{
+  unsigned int w, h;
+  Resolution( int _w, int _h) : w(_w), h(_h) {}
+};
+inline bool operator==(const Resolution& l, const Resolution& r) { return (l.w==r.w)&&(l.h==r.h); }
+inline bool operator<(const Resolution& l, const Resolution& r) { return (l.w<r.w)?true:((l.w==r.w)?((l.h<r.h)?true:false):false); }
+
+void BuildListOfMainDisplayResolutions(std::set<Resolution> &resolutions)
+{
+  CGDirectDisplayID monitorID = CGMainDisplayID();
+  CFArrayRef modes = CGDisplayCopyAllDisplayModes(monitorID, NULL);
+  CFIndex found = CFArrayGetCount(modes);
+  
+  for (CFIndex i = 0;  i < found;  i++)
+  {
+    CGDisplayModeRef dm = (CGDisplayModeRef) CFArrayGetValueAtIndex(modes, i);
+    resolutions.insert({(int)CGDisplayModeGetWidth(dm), (int)CGDisplayModeGetHeight(dm)});
+  }
+  CFRelease(modes);
+}
+
+bool Renderer::OpenSetupDialog( RENDERER_SETTINGS * settings )
+{
+  std::set<Resolution> resolutions;
+  
+  // Force some default resolutions
+  resolutions.insert({1280, 720});
+  resolutions.insert({1920, 1080});
+  // Also add the resolution found in the settings
+  resolutions.insert({settings->nWidth, settings->nHeight});
+  
+  BuildListOfMainDisplayResolutions(resolutions);
+  
+  CFURLRef urlRef = CFBundleCopyResourceURL(CFBundleGetMainBundle(), CFSTR("icon"), CFSTR("icns"), NULL);
+  
+  // The list of resolutions for the dialog
+  CFMutableArrayRef popupVals = CFArrayCreateMutable(NULL, resolutions.size(), &kCFTypeArrayCallBacks);
+  for (const auto &r: resolutions) {
+    CFArrayAppendValue(popupVals, CFStringCreateWithFormat(NULL, NULL, CFSTR("%d x %d"), r.w, r.h));
+  }
+  
+  // The fullscreen checkbox for the dialog
+  CFTypeRef checkboxKeys[1] = { CFSTR("Fullscreen?") };
+  CFArrayRef checkboxVals = CFArrayCreate( NULL, checkboxKeys, 1, &kCFTypeArrayCallBacks);
+  
+  const void* keys[] = {
+    kCFUserNotificationIconURLKey,
+    kCFUserNotificationAlertHeaderKey,
+    kCFUserNotificationAlertMessageKey,
+    kCFUserNotificationDefaultButtonTitleKey,
+    kCFUserNotificationPopUpTitlesKey,
+    kCFUserNotificationCheckBoxTitlesKey
+  };
+  const void* values[] = {
+    urlRef,
+    CFSTR("Bonzomatic"),
+    CFSTR("Choose your resolution, it's a REVOLUTION!\n\nNote: The list is polled from your main display, but 1920x1080 and 1280x720 are force inserted and NOT garanteed to work on your device.\nWe also add whatever was found in the \"config.json\"\n"),
+    CFSTR("Ignition"),
+    popupVals,
+    checkboxVals
+  };
+  CFDictionaryRef parameters = CFDictionaryCreate(NULL, keys, values, sizeof(keys)/sizeof(*keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+  
+  // Setup defaults according to the settings
+  CFOptionFlags settingsFlags = 0;
+  if (settings->windowMode == RENDERER_WINDOWMODE_FULLSCREEN) {
+    settingsFlags |= CFUserNotificationCheckBoxChecked(0);
+  }
+  int idx=0;
+  for (const auto &r: resolutions) {
+    if ((settings->nWidth == r.w) && (settings->nHeight == r.h)) {
+      settingsFlags |= CFUserNotificationPopUpSelection(idx);
+      break;
+    }
+    idx++;
+  }
+  
+  SInt32 err = 0;
+  CFUserNotificationRef dialog = CFUserNotificationCreate(NULL, 0, kCFUserNotificationPlainAlertLevel | settingsFlags, &err, parameters);
+  
+  CFOptionFlags responseFlags = 0;
+  CFUserNotificationReceiveResponse(dialog, 0, &responseFlags);
+  
+  // Collect the user selection and feed the settings
+  if (responseFlags & CFUserNotificationCheckBoxChecked(0)) {
+    settings->windowMode = RENDERER_WINDOWMODE_FULLSCREEN;
+  } else {
+    settings->windowMode = RENDERER_WINDOWMODE_WINDOWED;
+  }
+  idx = responseFlags >> 24;
+  if ((idx >= 0) && (idx < resolutions.size())) {
+    const auto &r = *std::next(resolutions.cbegin(), idx);
+    settings->nWidth = r.w;
+    settings->nHeight = r.h;
+  }
+  
+  CFRelease(dialog);
+  CFRelease(parameters);
+  CFRelease(checkboxVals);
+  CFRelease(popupVals);
+
+  return true;
+}
+


### PR DESCRIPTION
Fullscreen modes are glitchy and dont guarantee obtaining requested resolution.
A few fixes are used to reset nWidth/nHeight and settings values to actual obtained resolution so that the interface is always working correctly whatever we get.

The dialog has 2 manually forced resolutions in the list: FullHD and HDReady. We also added whatever was eventually set in the 'config.json' so that users can manually add and try resolutions.

![](https://alkama.com/drop/bonzomaticselector.png)