### PR TITLE
Fix font Windows

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -218,6 +218,8 @@ int main(int argc, char *argv[])
           printf("Couldn't open the font file '%s'.\n", fontpath.c_str());
           return -1;
         }
+#else
+        editorOptions.sFontPath = fontpath;
 #endif
       }
       else if (!editorOptions.sFontPath.size()) // coudn't find a default font


### PR DESCRIPTION
There was a recently introduced bug where, at least in Windows, it no longer used the font specified in `config.json`. This bugfix rectifies this issue.