### PR TITLE
Keep the mac app bundle and windows exe name clean

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,6 @@ project(Bonzomatic)
 cmake_minimum_required(VERSION 3.0)
 
 set(CMAKE_OSX_ARCHITECTURES x86_64)
-set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 if (APPLE OR WIN32)
 	set(BZC_EXE_NAME "Bonzomatic")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,11 @@ cmake_minimum_required(VERSION 3.0)
 set(CMAKE_OSX_ARCHITECTURES x86_64)
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
-set(BZC_EXE_NAME "bonzomatic")
+if (APPLE OR WIN32)
+	set(BZC_EXE_NAME "Bonzomatic")
+else ()
+	set(BZC_EXE_NAME "bonzomatic")
+endif ()
 
 set(VERSION_MAJOR "1")
 set(VERSION_MINOR "0")

--- a/src/Platform.cpp
+++ b/src/Platform.cpp
@@ -354,7 +354,7 @@ void SurfaceImpl::RoundedRectangle(PRectangle rc, ColourDesired fore, ColourDesi
 void SurfaceImpl::AlphaRectangle(PRectangle rc, int /*cornerSize*/, ColourDesired fill, int alphaFill,
     ColourDesired /*outline*/, int /*alphaOutline*/, int /*flags*/) 
 {
-  unsigned int back = fill.AsLong() & 0xFFFFFF | ((alphaFill & 0xFF) << 24);
+  unsigned int back = (fill.AsLong() & 0xFFFFFF) | ((alphaFill & 0xFF) << 24);
   FillRectangle(rc, back);
 }
 

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -66,7 +66,7 @@ namespace Renderer
   struct Vertex
   {
     Vertex( float _x, float _y, unsigned int _c = 0xFFFFFFFF, float _u = 0.0, float _v = 0.0) : 
-      x(_x), y(_y), c(_c), u(_u), v(_v) {}
+      x(_x), y(_y), u(_u), v(_v), c(_c) {}
     float x, y;
     float u, v;
     unsigned int c;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,7 +53,7 @@ int main(int argc, const char *argv[])
 
     char szConfig[65535];
     memset( szConfig, 0, 65535 );
-    int n = fread( szConfig, 1, 65535, fConf );
+    fread( szConfig, 1, 65535, fConf );
     fclose(fConf);
 
     options.parse( szConfig );
@@ -214,7 +214,7 @@ int main(int argc, const char *argv[])
     printf("Loading last shader...\n");
 
     memset( szShader, 0, 65535 );
-    int n = fread( szShader, 1, 65535, f );
+    fread( szShader, 1, 65535, f );
     fclose(f);
     if (Renderer::ReloadShader( szShader, strlen(szShader), szError, 4096 ))
     {

--- a/src/platform_glfw/Renderer.cpp
+++ b/src/platform_glfw/Renderer.cpp
@@ -272,7 +272,7 @@ namespace Renderer
         return false;
     }
     printf("[GLFW] Using GLEW %s\n", glewGetString(GLEW_VERSION));
-    GLenum i = glGetError(); // reset glew error
+    glGetError(); // reset glew error
 
     glfwSwapInterval(1);
 

--- a/src/platform_osx/TouchBar.mm
+++ b/src/platform_osx/TouchBar.mm
@@ -21,7 +21,6 @@ static NSString *touchBarItemIdQuit = @"bonzomatic.quit";
 @interface TouchBar : NSObject <NSTouchBarDelegate>
 - (NSTouchBar *)makeTouchBar;
 - (NSTouchBarItem *)touchBar:(NSTouchBar *)touchBar makeItemForIdentifier:(NSTouchBarItemIdentifier)identifier;
-- (void)glfwButtonAction:(id)sender;
 
 typedef enum {
     toggleTextures,

--- a/src/platform_x11/Timer.cpp
+++ b/src/platform_x11/Timer.cpp
@@ -3,7 +3,7 @@
 #ifdef __MACH__
 #include <mach/clock.h>
 #include <mach/mach.h>
-#define CLOCK_MONOTONIC (0)
+#define BZC_CLOCK_MONOTONIC (0)
 // clock_gettime is not implemented on OSX
 int clock_gettime(int /*clk_id*/, struct timespec* ts) {
   clock_serv_t cclock;
@@ -15,6 +15,8 @@ int clock_gettime(int /*clk_id*/, struct timespec* ts) {
   ts->tv_nsec = mts.tv_nsec;
   return 0;
 }
+#else
+#define BZC_CLOCK_MONOTONIC CLOCK_MONOTONIC
 #endif
 
 namespace Timer
@@ -23,13 +25,13 @@ namespace Timer
 
   void Start()
   {
-    clock_gettime(CLOCK_MONOTONIC, &startTime);
+    clock_gettime(BZC_CLOCK_MONOTONIC, &startTime);
   }
 
   float GetTime()
   {
     timespec ts;
-    clock_gettime(CLOCK_MONOTONIC, &ts);
+    clock_gettime(BZC_CLOCK_MONOTONIC, &ts);
     ts.tv_sec -= startTime.tv_sec;
     ts.tv_nsec -= startTime.tv_nsec;
     double now = ts.tv_sec * 1e3 + ts.tv_nsec * 1e-6;


### PR DESCRIPTION
Let linux binary be lowercase.

Also delete the line setting CMake Module Path. It was pointing to a subdirectory we dont have anymore and was meant to help finding SDL2, which we removed.