### PR TITLE
Compile DX11 successfully on mingw32

### DIFF
--- a/src/platform_w32_dx11/Renderer.cpp
+++ b/src/platform_w32_dx11/Renderer.cpp
@@ -8,6 +8,10 @@
 
 #include "../Renderer.h"
 
+#ifndef WM_MOUSEHWHEEL
+#define WM_MOUSEHWHEEL (0x020E)
+#endif
+
 #define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
 #include "Scintilla.h"


### PR DESCRIPTION
Not sure how I got it to work before!  Anyway, this is the DX11 counterpart to the DX9 change in 7c927ba8a79f50e12373b1e5eb57ecf9b96d1230.