### PR TITLE
Fix final warning in Xcode 10 and add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Bonzomatic
 tmp
 build
 .vs
+.DS_Store

--- a/src/ShaderEditor.cpp
+++ b/src/ShaderEditor.cpp
@@ -80,7 +80,7 @@ public:
 static unsigned int wndID = 1;
 void ShaderEditor::Initialise()
 {
-  wMain = (Scintilla::WindowID)(wndID++);
+  wMain = (Scintilla::WindowID)(unsigned long)(wndID++);
 
   lexState = new Scintilla::LexState( pdoc );
 


### PR DESCRIPTION
There are still 57 warnings in the glfw library but that's mainly because OpenGL is now deprecated. This PR fixes the remaining warning in Bonzomatic.

It also adds .DS_Store to .gitignore because Macs will keep adding this file to folders and we don't want to commit it.