### PR TITLE
Added default ubuntu Mono font to Misc.cpp

### DIFF
--- a/src/platform_x11/Misc.cpp
+++ b/src/platform_x11/Misc.cpp
@@ -46,6 +46,7 @@ const char * Misc::GetDefaultFontPath()
     "/usr/share/fonts/TTF/VeraMono.ttf",
     "/usr/share/fonts/corefonts/cour.ttf",
     "/usr/share/fonts/truetype/msttcorefonts/cour.ttf",
+    "/usr/share/fonts/truetype/ubuntu-font-family/UbuntuMono-R.ttf",
     NULL
   };
   for (int i = 0; fontPaths[i]; ++i)


### PR DESCRIPTION
The fonts listed in Misc.cpp weren't available by default on Ubuntu 16.04.  This adds in the UbuntuMono-R.ttf monospace font.
