### PR TITLE
Linux fonts fix (Ubuntu at last) and readme for building under Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,23 @@ Create a `config.json` with e.g. the following contents: (all fields are optiona
 
 ## Building
 As you can see you're gonna need [CMAKE](https://cmake.org/) for this, but don't worry, a lot of it is automated at this point.
-* On Windows, use at least Visual C++ 2010. For the DX9/DX11 builds, obviously you'll be needing a DirectX SDK, though a lot of it is already in the Windows 8.1 SDK as well.
-* On Linux, you'll need ```xorg-dev``` and ```libglu1-mesa-dev```; after that ```cmake``` should take care of the rest.
-* On OSX, ```cmake``` should take care of everything.
+
+### Windows
+Use at least Visual C++ 2010. For the DX9/DX11 builds, obviously you'll be needing a DirectX SDK, though a lot of it is already in the Windows 8.1 SDK as well.
+
+### OSX/macOS
+The ```cmake``` should take care of everything.
+
+### Linux
+You'll need ```xorg-dev``` and ```libglu1-mesa-dev```; after that ```cmake``` should take care of the rest.
+
+```
+apt install xorg-dev libglu1-mesa-dev cmake
+cd Bonzomatic
+cmake .
+make
+make install
+```
 
 ## Organizing a competition
 If you want to organize a competition using Bonzomatic at your party, here's a handy-dandy guide on how to get started:

--- a/src/platform_x11/Misc.cpp
+++ b/src/platform_x11/Misc.cpp
@@ -40,12 +40,15 @@ const char * Misc::GetDefaultFontPath()
   // TODO: use fonts.conf(5) or X resources or something like that
   const char* fontPaths[] =
   {
-    "/usr/share/fonts/truetype/freefont/DejaVuSansMono.ttf",
+    "/usr/share/fonts/TTF/DejaVuSansMono.ttf",
+    "/usr/share/fonts/TTF/FreeMono.ttf",
+    "/usr/share/fonts/TTF/LiberationMono-Regular.ttf",
+    "/usr/share/fonts/TTF/VeraMono.ttf",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf",
     "/usr/share/fonts/truetype/freefont/FreeMono.ttf",
-    "/usr/share/fonts/truetype/freefont/LiberationMono-Regular.ttf",
-    "/usr/share/fonts/truetype/freefont/VeraMono.ttf",
-    "/usr/share/fonts/corefonts/cour.ttf",
+    "/usr/share/fonts/truetype/liberation/LiberationMono-Regular.ttf",
     "/usr/share/fonts/truetype/msttcorefonts/cour.ttf",
+    "/usr/share/fonts/corefonts/cour.ttf",
     NULL
   };
   for (int i = 0; fontPaths[i]; ++i)

--- a/src/platform_x11/Misc.cpp
+++ b/src/platform_x11/Misc.cpp
@@ -40,10 +40,10 @@ const char * Misc::GetDefaultFontPath()
   // TODO: use fonts.conf(5) or X resources or something like that
   const char* fontPaths[] =
   {
-    "/usr/share/fonts/TTF/DejaVuSansMono.ttf",
-    "/usr/share/fonts/TTF/FreeMono.ttf",
-    "/usr/share/fonts/TTF/LiberationMono-Regular.ttf",
-    "/usr/share/fonts/TTF/VeraMono.ttf",
+    "/usr/share/fonts/truetype/freefont/DejaVuSansMono.ttf",
+    "/usr/share/fonts/truetype/freefont/FreeMono.ttf",
+    "/usr/share/fonts/truetype/freefont/LiberationMono-Regular.ttf",
+    "/usr/share/fonts/truetype/freefont/VeraMono.ttf",
     "/usr/share/fonts/corefonts/cour.ttf",
     "/usr/share/fonts/truetype/msttcorefonts/cour.ttf",
     NULL


### PR DESCRIPTION
For non programmers it's not obvious how to compile using cmake (put dot as parameter).

The font's paths are also strange. It there is a linux distribution that have those paths then I will just add new paths instead of changing the old.