### PR TITLE
[macOS] Fix Touchbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ On Windows, both DirectX 9 and 11 are supported.
 
 For the OpenGL version (for any platform), at least OpenGL 4.1 is required.
 
-On MacBooks with a TouchBar that are running macOS Mojave: Open up System Preferences, click on Security & Privacy, click on the privacy tab then click on the Accessibility menu item. Make sure Bonzomatic.app is ticked, otherwise only the "Quit" TouchBar button will work.
+On recent macOS, to allow sound input to be captured (for FFT textures to be generated), you need to: Open up System Preferences, click on Security & Privacy, click on the Privacy tab then click on the Microphone menu item. Make sure Bonzomatic.app is in the list and ticked.
 
 ## Configuration
 Create a `config.json` with e.g. the following contents: (all fields are optional)
@@ -113,7 +113,7 @@ https://github.com/Gargaj/Bonzomatic/wiki/How-to-set-up-a-Live-Coding-compo
 
 These software are available under their respective licenses.
 
-The remainder of this project code was (mostly, I guess) written by Gargaj / Conspiracy and is public domain. OSX / macOS maintenance and ports by Alkama / Calodox; Linux maintenance by PoroCYon / K2.
+The remainder of this project code was (mostly, I guess) written by Gargaj / Conspiracy and is public domain.OSX / macOS maintenance and ports by Alkama / Tpolm + Calodox; Linux maintenance by PoroCYon / K2.
 
 ## Contact / discussion forum
 If you have anything to say, do it at http://www.pouet.net/topic.php?which=9881 or [![Join the chat at https://gitter.im/Gargaj/Bonzomatic](https://badges.gitter.im/Gargaj/Bonzomatic.svg)](https://gitter.im/Gargaj/Bonzomatic?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)

--- a/src/platform_osx/TouchBar.mm
+++ b/src/platform_osx/TouchBar.mm
@@ -10,6 +10,7 @@
 #import <Foundation/Foundation.h>
 #include <AppKit/AppKit.h>
 #import "../TouchBar.h"
+#include "../Renderer.h"
 
 static NSString *touchBarCustomizationId = @"com.something.customization_id";
 static NSString *touchBarItemIdCompile = @"bonzomatic.compile";
@@ -116,30 +117,22 @@ typedef enum {
 }
 
 - (void)sendKeyboardCommandForCommand:(BonzomaticCommand)command {
-    pid_t pid = [NSRunningApplication currentApplication].processIdentifier;
-    
-    CGEventRef event1, event2;
-    
+    Renderer::keyEventBuffer[Renderer::keyEventBufferCount].ctrl  = 0;
+    Renderer::keyEventBuffer[Renderer::keyEventBufferCount].alt   = 0;
+    Renderer::keyEventBuffer[Renderer::keyEventBufferCount].shift = 0;
+    Renderer::keyEventBuffer[Renderer::keyEventBufferCount].character = 0;
     switch (command) {
         case toggleGUI:
-            event1 = CGEventCreateKeyboardEvent (NULL, kVK_F11, true);
-            event2 = CGEventCreateKeyboardEvent (NULL, kVK_F11, false);
+            Renderer::keyEventBuffer[Renderer::keyEventBufferCount].scanCode = 292;
             break;
         case toggleTextures:
-            event1 = CGEventCreateKeyboardEvent (NULL, kVK_F2, true);
-            event2 = CGEventCreateKeyboardEvent (NULL, kVK_F2, false);
+            Renderer::keyEventBuffer[Renderer::keyEventBufferCount].scanCode = 283;
             break;
         case compile:
-            event1 = CGEventCreateKeyboardEvent (NULL, kVK_F5, true);
-            event2 = CGEventCreateKeyboardEvent (NULL, kVK_F5, false);
+            Renderer::keyEventBuffer[Renderer::keyEventBufferCount].scanCode = 286;
             break;
     }
-    
-    CGEventPostToPid(pid, event1);
-    CGEventPostToPid(pid, event2);
-    
-    CFRelease(event1);
-    CFRelease(event2);
+    Renderer::keyEventBufferCount++;
 }
 
 @end


### PR DESCRIPTION
Make the touchbar use the standard keyEventBuffer of the Renderer directly instead of trying some hazardous sending of keys to the process.

Wasn't working on 10.14, now it does :D