### PR TITLE
Smart indentation support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,15 +62,6 @@ if (APPLE)
   set(CMAKE_XCODE_ATTRIBUTE_GCC_ENABLE_CPP_EXCEPTIONS "No")
   set(CMAKE_XCODE_ATTRIBUTE_GCC_ENABLE_CPP_RTTI "No")
 endif ()
-if (UNIX AND (NOT APPLE)) #if not linux
-  if (CMAKE_VERSION VERSION_LESS "3.1")
-    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-      set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
-    endif ()
-  else ()
-    set (CMAKE_CXX_STANDARD 11)
-  endif ()
-endif ()
 
 # Dont compile glfw and glew for windows dx targets
 if (APPLE OR UNIX OR (WIN32 AND (${BONZOMATIC_WINDOWS_FLAVOR} MATCHES "GLFW")))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,15 @@ if (APPLE)
   set(CMAKE_XCODE_ATTRIBUTE_GCC_ENABLE_CPP_EXCEPTIONS "No")
   set(CMAKE_XCODE_ATTRIBUTE_GCC_ENABLE_CPP_RTTI "No")
 endif ()
+if (UNIX AND (NOT APPLE)) #if not linux
+  if (CMAKE_VERSION VERSION_LESS "3.1")
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+      set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
+    endif ()
+  else ()
+    set (CMAKE_CXX_STANDARD 11)
+  endif ()
+endif ()
 
 # Dont compile glfw and glew for windows dx targets
 if (APPLE OR UNIX OR (WIN32 AND (${BONZOMATIC_WINDOWS_FLAVOR} MATCHES "GLFW")))

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Create a `config.json` with e.g. the following contents: (all fields are optiona
     "spacesForTabs": false,
     "tabSize": 8,
     "visibleWhitespace": true,
-    "autoindent": "smart", // can be "none", "preserve" or "smart"
+    "autoIndent": "smart", // can be "none", "preserve" or "smart"
   },
   "midi":{ // the keys below will become the shader variable names, the values are the CC numbers
     "fMidiKnob": 16, // e.g. this would be CC#16, i.e. by default the leftmost knob on a nanoKONTROL 2

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Create a `config.json` with e.g. the following contents: (all fields are optiona
     "spacesForTabs": false,
     "tabSize": 8,
     "visibleWhitespace": true,
+    "autoindent": "smart", // can be "none", "preserve" or "smart"
   },
   "midi":{ // the keys below will become the shader variable names, the values are the CC numbers
     "fMidiKnob": 16, // e.g. this would be CC#16, i.e. by default the leftmost knob on a nanoKONTROL 2

--- a/src/ShaderEditor.cpp
+++ b/src/ShaderEditor.cpp
@@ -1,5 +1,4 @@
 #include <cstring>
-#include <iterator>
 #include "ShaderEditor.h"
 #include "Renderer.h"
 #include "PropSetSimple.h"

--- a/src/ShaderEditor.cpp
+++ b/src/ShaderEditor.cpp
@@ -495,25 +495,38 @@ std::vector<std::string> ShaderEditor::GetLinePartsInStyle(int line, int style) 
   return out;
 }
 
+bool ShaderEditor::isAStatementIndent(std::string &word) {
+  for (size_t i=0; i<(sizeof(statementIndent)/sizeof(statementIndent[0])); i++) {
+    std::string &statementElem = statementIndent[i];
+    if (statementElem == word) {
+      return true;
+    }
+  }
+  return false;
+}
+
 ShaderEditor::IndentationStatus ShaderEditor::GetIndentState(int line) {
+  size_t i;
   IndentationStatus indentState = isNone;
   std::vector<std::string> controlWords = GetLinePartsInStyle(line, statementIndentStyleNumber);
-  for (auto &controlWord : controlWords) {
-    std::string *foo = std::find(std::begin(statementIndent), std::end(statementIndent), controlWord);
-    if (foo != std::end(statementIndent)) {
+  for (i=0; i<controlWords.size(); i++) {
+    std::string &controlWord = controlWords[i];
+    if (isAStatementIndent(controlWord)) {
       indentState = isKeyWordStart;
     }
   }
   
   controlWords = GetLinePartsInStyle(line, blockAndStatementEndStyleNumber);
-  for (auto &controlWord : controlWords) {
+  for (i=0; i<controlWords.size(); i++) {
+    std::string &controlWord = controlWords[i];
     if (controlWord.size() < 1) continue;
     if (statementEnd == controlWord[0]) {
       indentState = isNone;
     }
   }
   
-  for (auto &controlWord : controlWords) {
+  for (i=0; i<controlWords.size(); i++) {
+    std::string &controlWord = controlWords[i];
     if (controlWord.size() < 1) continue;
     if (blockEnd == controlWord[0]) {
       indentState = isBlockEnd;

--- a/src/ShaderEditor.h
+++ b/src/ShaderEditor.h
@@ -138,6 +138,7 @@ private:
   void SetLineIndentation(int line, int indent);
   void PreserveIndentation(char ch);
   std::vector<std::string> GetLinePartsInStyle(int line, int style);
+  bool isAStatementIndent(std::string &word);
   IndentationStatus GetIndentState(int line);
   int IndentOfBlock(int line);
   bool RangeIsAllWhitespace(int start, int end);

--- a/src/ShaderEditor.h
+++ b/src/ShaderEditor.h
@@ -137,7 +137,7 @@ private:
   int GetLineIndentPosition(int line);
   void SetLineIndentation(int line, int indent);
   void PreserveIndentation(char ch);
-  unsigned int GetLinePartsInStyle(int line, int style, std::string sv[], int len);
+  std::vector<std::string> GetLinePartsInStyle(int line, int style);
   IndentationStatus GetIndentState(int line);
   int IndentOfBlock(int line);
   bool RangeIsAllWhitespace(int start, int end);

--- a/src/ShaderEditor.h
+++ b/src/ShaderEditor.h
@@ -48,6 +48,12 @@
 #include <ExternalLexer.h>
 #endif
 
+enum AutoIndentationType {
+  aitNone,
+  aitPreserve,
+  aitSmart
+};
+
 struct SHADEREDITOR_OPTIONS {
   std::string sFontPath;
   int nFontSize;
@@ -56,6 +62,7 @@ struct SHADEREDITOR_OPTIONS {
   bool bUseSpacesForTabs;
   int nTabSize;
   bool bVisibleWhitespace;
+  AutoIndentationType eAutoIndent;
 };
 
 class ShaderEditor : public Scintilla::Editor
@@ -71,6 +78,7 @@ class ShaderEditor : public Scintilla::Editor
   bool bUseSpacesForTabs;
   int nTabSize;
   bool bVisibleWhitespace;
+  AutoIndentationType eAutoIndent;
 
 public:
   ShaderEditor(Scintilla::Surface *surfaceWindow);
@@ -115,6 +123,13 @@ public:
   Scintilla::Font * GetTextFont();
     
 private:
+  enum IndentationStatus {
+    isNone,        // no effect on indentation
+    isBlockStart,  // indentation block begin such as "{" or VB "function"
+    isBlockEnd,    // indentation end indicator such as "}" or VB "end"
+    isKeyWordStart // Keywords that cause indentation
+  };
+  
   int GetLineLength(int line);
   int GetCurrentLineNumber();
   Scintilla::Sci_CharacterRange GetSelection();
@@ -122,4 +137,9 @@ private:
   int GetLineIndentPosition(int line);
   void SetLineIndentation(int line, int indent);
   void PreserveIndentation(char ch);
+  unsigned int GetLinePartsInStyle(int line, int style, std::string sv[], int len);
+  IndentationStatus GetIndentState(int line);
+  int IndentOfBlock(int line);
+  bool RangeIsAllWhitespace(int start, int end);
+  void AutomaticIndentation(char ch);
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -182,12 +182,12 @@ int main(int argc, const char *argv[])
         editorOptions.nTabSize = options.get<jsonxx::Object>("gui").get<jsonxx::Number>("tabSize");
       if (options.get<jsonxx::Object>("gui").has<jsonxx::Boolean>("visibleWhitespace"))
         editorOptions.bVisibleWhitespace = options.get<jsonxx::Object>("gui").get<jsonxx::Boolean>("visibleWhitespace");
-      if (options.get<jsonxx::Object>("gui").has<jsonxx::String>("autoindent"))
+      if (options.get<jsonxx::Object>("gui").has<jsonxx::String>("autoIndent"))
       {
-        std::string autoindent = options.get<jsonxx::Object>("gui").get<jsonxx::String>("autoindent");
-        if (autoindent == "smart") {
+        std::string autoIndent = options.get<jsonxx::Object>("gui").get<jsonxx::String>("autoIndent");
+        if (autoIndent == "smart") {
           editorOptions.eAutoIndent = aitSmart;
-        } else if (autoindent == "preserve") {
+        } else if (autoIndent == "preserve") {
           editorOptions.eAutoIndent = aitPreserve;
         } else {
           editorOptions.eAutoIndent = aitNone;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -117,6 +117,7 @@ int main(int argc, const char *argv[])
   editorOptions.bUseSpacesForTabs = true;
   editorOptions.nTabSize = 2;
   editorOptions.bVisibleWhitespace = false;
+  editorOptions.eAutoIndent = aitSmart;
 
   int nDebugOutputHeight = 200;
   int nTexPreviewWidth = 64;
@@ -181,6 +182,17 @@ int main(int argc, const char *argv[])
         editorOptions.nTabSize = options.get<jsonxx::Object>("gui").get<jsonxx::Number>("tabSize");
       if (options.get<jsonxx::Object>("gui").has<jsonxx::Boolean>("visibleWhitespace"))
         editorOptions.bVisibleWhitespace = options.get<jsonxx::Object>("gui").get<jsonxx::Boolean>("visibleWhitespace");
+      if (options.get<jsonxx::Object>("gui").has<jsonxx::String>("autoindent"))
+      {
+        std::string autoindent = options.get<jsonxx::Object>("gui").get<jsonxx::String>("autoindent");
+        if (autoindent == "smart") {
+          editorOptions.eAutoIndent = aitSmart;
+        } else if (autoindent == "preserve") {
+          editorOptions.eAutoIndent = aitPreserve;
+        } else {
+          editorOptions.eAutoIndent = aitNone;
+        }
+      }
     }
     if (options.has<jsonxx::Object>("midi"))
     {


### PR DESCRIPTION
Indentation support can be set to `smart` (default), `preserve` or `none` in the `gui` section of the config file.
Readme file has been updated accordingly.

Heavily based on SciTe official implementation.