### PR TITLE
Prevent fullscreen window minimize on focus loss

### DIFF
--- a/src/platform_glfw/Renderer.cpp
+++ b/src/platform_glfw/Renderer.cpp
@@ -249,6 +249,9 @@ namespace Renderer
     // TODO: change in case of resize support
     glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE);
 
+    // Prevent fullscreen window minimize on focus loss
+    glfwWindowHint(GLFW_AUTO_ICONIFY, GL_FALSE);
+
     GLFWmonitor *monitor = settings->windowMode == RENDERER_WINDOWMODE_FULLSCREEN ? glfwGetPrimaryMonitor() : NULL;
 
     mWindow = glfwCreateWindow(nWidth, nHeight, "BONZOMATIC - GLFW edition", monitor, NULL);


### PR DESCRIPTION
Added one line, setting GLFW_AUTO_ICONIFY to GL_FALSE (default is GL_TRUE).

This prevents GLFW from minimizing on loss of focus, when used in fullscreen mode.

Very useful on multi-monitor setups:

GLFW-Bonzomatic can be used in fullscreen mode without minimizing, when doing something else in another window on another monitor.

Without this change, GLFW-Bonzomatic has to be run with fullscreen:false in config.json in a window to prevent minimization.

Only tested on Linux (where GLFW is the only option!) - should work on other platforms, too.