### PR TITLE
The custom plist is mandatory for mic access

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,6 @@ endif ()
 
 if (APPLE)
   option(BONZOMATIC_TOUCHBAR "Compile with macOS TouchBar support (Xcode 9 or newer required)?" ON)
-  option(BONZOMATIC_RETINA "Support HiDPI (warning: huge framebuffer, low fps in sight)?" OFF)
 endif ()
 
 if (WIN32)
@@ -463,12 +462,9 @@ if (UNIX AND (NOT APPLE))
     set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib")
 endif ()
 add_executable(${BZC_EXE_NAME} ${BZC_PROJECT_SRCS})
-if (APPLE AND BONZOMATIC_RETINA)
-  # Add special plist to enable Retina display support
-  set_target_properties(${BZC_EXE_NAME} PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/data/macosx/MacOSXBundleInfo.plist.in)
-endif ()
 # Set compiler specific flags
 if (APPLE)
+  set_target_properties(${BZC_EXE_NAME} PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/data/macosx/MacOSXBundleInfo.plist.in)
   if (BONZOMATIC_TOUCHBAR)
     target_compile_definitions(${BZC_EXE_NAME} PUBLIC -DBONZOMATIC_ENABLE_TOUCHBAR)
   endif ()

--- a/data/macosx/MacOSXBundleInfo.plist.in
+++ b/data/macosx/MacOSXBundleInfo.plist.in
@@ -26,20 +26,12 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
-	<key>NSHumanReadableCopyright</key>
-	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
-	<key>NSMainNibFile</key>
-	<string>appnib</string>
-	<key>NSPrincipalClass</key>
-	<string>NSApplication</string>
-	<key>NSHighResolutionCapable</key>
-	<true/>
 	<key>CSResourcesFileMapped</key>
 	<true/>
-	<key>LSRequiresCarbon</key>
+	<key>NSHumanReadableCopyright</key>
+	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
+	<key>NSHighResolutionCapable</key>
 	<true/>
-	<key>LSMinimumSystemVersion</key>
-	<string>10.6.4</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Bonzomatic requires microphone access for the FFT textures to work.</string>
 </dict>


### PR DESCRIPTION
Fixes a crash with PR #108

The custom plist was only used when retina support was checked, resulting in a missing key and an app crash (lack of mandatory message).

Also remove retina option from cmake. It makes no sense since it messes all the scintilla mouse selection and doesn't mirror the resolution selection (by nature). If people want to go HiDpi, they better request for a high resolution and have their wish come true.

Fake supporting HiDpi for a better window UI appearance in windowed mode.