### PR TITLE
Custom scroll speed via config.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ The file can have the following contents: (all fields are optional)
     "tabSize": 8,
     "visibleWhitespace": true,
     "autoIndent": "smart", // can be "none", "preserve" or "smart"
+    "scrollXFactor": 1.0, // if horizontal scrolling is too slow you can speed it up here (or change direction)
+    "scrollYFactor": 1.0, // if vertical scrolling is too slow you can speed it up here (or change direction)
   },
   "midi":{ // the keys below will become the shader variable names, the values are the CC numbers
     "fMidiKnob": 16, // e.g. this would be CC#16, i.e. by default the leftmost knob on a nanoKONTROL 2

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -101,8 +101,8 @@ namespace Renderer
   struct MouseEvent
   {
     MOUSEEVENTTYPE eventType;
-    int x;
-    int y;
+    float x;
+    float y;
     MOUSEBUTTON button;
   };
   extern MouseEvent mouseEventBuffer[512];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -147,6 +147,8 @@ int main(int argc, const char *argv[])
   int nTexPreviewWidth = 64;
   float fFFTSmoothingFactor = 0.9f; // higher value, smoother FFT
   float fFFTSlightSmoothingFactor = 0.6f; // higher value, smoother FFT
+  float fScrollXFactor = 1.0f;
+  float fScrollYFactor = 1.0f;
 
   std::string sPostExitCmd;
 
@@ -217,6 +219,10 @@ int main(int argc, const char *argv[])
           editorOptions.eAutoIndent = aitNone;
         }
       }
+      if (options.get<jsonxx::Object>("gui").has<jsonxx::Number>("scrollXFactor"))
+        fScrollXFactor = options.get<jsonxx::Object>("gui").get<jsonxx::Number>("scrollXFactor");
+      if (options.get<jsonxx::Object>("gui").has<jsonxx::Number>("scrollYFactor"))
+        fScrollYFactor = options.get<jsonxx::Object>("gui").get<jsonxx::Number>("scrollYFactor");
     }
     if (options.has<jsonxx::Object>("midi"))
     {
@@ -351,7 +357,7 @@ int main(int argc, const char *argv[])
             mShaderEditor.ButtonUp( Scintilla::Point( Renderer::mouseEventBuffer[i].x, Renderer::mouseEventBuffer[i].y ), time * 1000, false );
             break;
           case Renderer::MOUSEEVENTTYPE_SCROLL:
-            mShaderEditor.WndProc( SCI_LINESCROLL, -Renderer::mouseEventBuffer[i].x, -Renderer::mouseEventBuffer[i].y);
+            mShaderEditor.WndProc( SCI_LINESCROLL, (int)(-Renderer::mouseEventBuffer[i].x * fScrollXFactor), (int)(-Renderer::mouseEventBuffer[i].y * fScrollYFactor));
             break;
         }
       }


### PR DESCRIPTION
Precision trackpads sometimes have slower scrolls, especially on GLFW.
This gives some control on speed (and direction in case one wants to invert scrolls) via simple factors.

Note: Had to change MouseEvent to capture float values and only convert to int after the factor is applied. It should not impact the clicks since integer values should be represented just as fine with floats.