### PR TITLE
Make the clipboard on windows great again

### DIFF
--- a/src/ShaderEditor.cpp
+++ b/src/ShaderEditor.cpp
@@ -193,6 +193,8 @@ void ShaderEditor::Copy()
 void ShaderEditor::Paste()
 {
   int n = Clipboard::GetContentsLength();
+  if (n == 0) return;
+
   char * p = new char[n + 1];
   memset(p,0,n+1);
   Clipboard::GetContents( p, n );

--- a/src/platform_w32_common/Clipboard.cpp
+++ b/src/platform_w32_common/Clipboard.cpp
@@ -8,16 +8,27 @@ namespace Clipboard
     if ( !::OpenClipboard( hWnd ) )
       return;
 
-    EmptyClipboard();
+    HGLOBAL hData = GlobalAlloc( GMEM_MOVEABLE, ( len + 1 ) * sizeof( char ) );
+    if ( !hData ) {
+      CloseClipboard();
+      return;
+    }
 
-    HGLOBAL h = GlobalAlloc( GMEM_MOVEABLE, ( len + 1 ) * sizeof( char ) );
-    WCHAR * pMem = (WCHAR*) GlobalLock( h );
+    WCHAR * pMem = (WCHAR*) GlobalLock( hData );
+    if ( !pMem ) {
+      GlobalFree( hData );
+      CloseClipboard();
+      return;
+    }
 
     ZeroMemory( pMem, ( len + 1 ) * sizeof( char ) );
     CopyMemory( pMem, data, ( len + 1 ) * sizeof( char ) );
 
-    GlobalUnlock( h );
-    SetClipboardData( CF_TEXT, h );
+    GlobalUnlock( hData );
+
+    EmptyClipboard();
+
+    SetClipboardData( CF_TEXT, hData );
 
     CloseClipboard();
   }
@@ -29,8 +40,20 @@ namespace Clipboard
       return 0;
 
     HANDLE hData = GetClipboardData( CF_TEXT );
+    if ( !hData ) {
+      CloseClipboard();
+      return 0;
+    }
+
     const char * buffer = (const char*) GlobalLock( hData );
+    if ( !buffer ) {
+      CloseClipboard();
+      return 0;
+    }
+
     int n = strlen( buffer );
+
+    GlobalUnlock( hData );
 
     CloseClipboard();
 
@@ -44,8 +67,20 @@ namespace Clipboard
       return;
 
     HANDLE hData = GetClipboardData( CF_TEXT );
+    if ( !hData ) {
+      CloseClipboard();
+      return;
+    }
+
     const char * buffer = (const char*) GlobalLock( hData );
+    if ( !buffer ) {
+      CloseClipboard();
+      return;
+    }
+
     strncpy( data, buffer, len );
+
+    GlobalUnlock( hData );
 
     CloseClipboard();
   }


### PR DESCRIPTION
Fixes crashes on clipboard handling.
Also don't paste when there's nothing to paste.

This needs peer review as I'm not a windows specialist, but this looks way safer and indeed fixes crashes I experienced.