### PR TITLE
Add shader error to 'vertex shader compilation failed' msg

### DIFF
--- a/src/platform_glfw/Renderer.cpp
+++ b/src/platform_glfw/Renderer.cpp
@@ -345,7 +345,7 @@ namespace Renderer
     glGetShaderiv(glhVertexShader, GL_COMPILE_STATUS, &result);
     if (!result)
     {
-      printf("[Renderer] Vertex shader compilation failed\n");
+      printf("[Renderer] Vertex shader compilation failed\n%s\n", szErrorBuffer);
       return false;
     }
 


### PR DESCRIPTION
Useful for figuring out if a version of OpenGL isn't available, or other weird errors.