### PR TITLE
Added new default font location for OSX Catalina (fixes #117)

### DIFF
--- a/src/platform_osx/Misc.mm
+++ b/src/platform_osx/Misc.mm
@@ -118,6 +118,7 @@ const char * Misc::GetDefaultFontPath()
   const char* fontPaths[] =
   {
     "/Library/Fonts/Courier New.ttf",
+    "/System/Library/Fonts/Supplemental/Courier New.ttf",
     NULL
   };
   for (int i = 0; fontPaths[i]; ++i)


### PR DESCRIPTION
Added new file location for `Courier New` on Catalina. Alternative fix to #133.