### PR TITLE
Set locale to be 'C' to fix weird arrow key bug

### DIFF
--- a/src/platform_x11/Misc.cpp
+++ b/src/platform_x11/Misc.cpp
@@ -20,7 +20,7 @@ void Misc::PlatformShutdown()
 
 void Misc::InitKeymaps()
 {
-  return;
+  setlocale(LC_ALL, "C");
 }
 
 void Misc::GetKeymapName(char* sz)


### PR DESCRIPTION
fixes #144

I encountered this when I added gtk to the build in a different branch. idk why it's happening here, but it fixes it