### PR TITLE
Fix none-indent behaving as though smart-indent were enabled

### DIFF
--- a/src/ShaderEditor.cpp
+++ b/src/ShaderEditor.cpp
@@ -248,7 +248,7 @@ void ShaderEditor::NotifyParent( Scintilla::SCNotification scn )
       char ch = static_cast<char>(scn.ch);
       if(eAutoIndent == aitPreserve) {
         PreserveIndentation(ch);
-      } else if (aitSmart) {
+      } else if (eAutoIndent == aitSmart) {
         AutomaticIndentation(ch);
       }
       break;


### PR DESCRIPTION
Addresses a minor flaw in the indent handling code, which meant that setting indent mode to "none" would still act as though it was using "smart" indent rules.