### PR TITLE
cmake: explicitly enable building a mac bundle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -427,7 +427,7 @@ if (WIN32)
 ############################################################################
 # MacOS
 elseif (APPLE)
-  set_target_properties(${BZC_EXE_NAME} PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/data/macosx/MacOSXBundleInfo.plist.in)
+  set_target_properties(${BZC_EXE_NAME} PROPERTIES MACOSX_BUNDLE ON MACOSX_BUNDLE_BUNDLE_NAME "Bonzomatic" MACOSX_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/data/macosx/MacOSXBundleInfo.plist.in)
   if (BONZOMATIC_TOUCHBAR)
     target_compile_definitions(${BZC_EXE_NAME} PUBLIC -DBONZOMATIC_ENABLE_TOUCHBAR)
   endif ()


### PR DESCRIPTION
Without this change, cmake would build a binary, but not an .app bundle.
Launching the binary would result in a crash.

With this change, a working .app file is built.

#revision2021