### PR TITLE
Can vertically flip textures after loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The file can have the following contents: (all fields are optional)
   "rendering":{
     "fftSmoothFactor": 0.9, // 0.0 means there's no smoothing at all, 1.0 means the FFT is completely smoothed flat
     "fftAmplification": 1.0, // 1.0 means no change, larger values will result in brighter/stronger bands, smaller values in darker/weaker ones
+    "textureFlipY": true, // whether textures are vertically flipped after loading (default: false)
   },
   "textures":{ // the keys below will become the shader variable names
     "texChecker":"textures/checker.png",

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -43,6 +43,8 @@ namespace Renderer
 
   void Close();
 
+  void SetTextureFlipY(bool flipY);
+
   enum TEXTURETYPE
   {
     TEXTURETYPE_1D = 1,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -197,10 +197,14 @@ int main( int argc, const char *argv[] )
         fFFTSmoothingFactor = options.get<jsonxx::Object>("rendering").get<jsonxx::Number>("fftSmoothFactor");
       if (options.get<jsonxx::Object>("rendering").has<jsonxx::Number>("fftAmplification"))
         FFT::fAmplification = options.get<jsonxx::Object>("rendering").get<jsonxx::Number>("fftAmplification");
+      if (options.get<jsonxx::Object>("rendering").has<jsonxx::Boolean>("textureFlipY"))
+        bTextureFlipY = options.get<jsonxx::Object>("rendering").get<jsonxx::Boolean>("textureFlipY");
     }
 
     if (options.has<jsonxx::Object>("textures"))
     {
+      Renderer::SetTextureFlipY(bTextureFlipY);
+
       printf("Loading textures...\n");
       std::map<std::string, jsonxx::Value*> tex = options.get<jsonxx::Object>("textures").kv_map();
       for (std::map<std::string, jsonxx::Value*>::iterator it = tex.begin(); it != tex.end(); it++)

--- a/src/platform_glfw/Renderer.cpp
+++ b/src/platform_glfw/Renderer.cpp
@@ -685,6 +685,11 @@ namespace Renderer
     }
   }
 
+  void SetTextureFlipY(bool flipY)
+  {
+    stbi_set_flip_vertically_on_load(flipY);
+  }
+
   struct GLTexture : public Texture
   {
     GLuint ID;

--- a/src/platform_w32_dx11/Renderer.cpp
+++ b/src/platform_w32_dx11/Renderer.cpp
@@ -886,6 +886,11 @@ namespace Renderer
     __UpdateConstants();
   }
 
+  void SetTextureFlipY(bool flipY)
+  {
+    stbi_set_flip_vertically_on_load(flipY);
+  }
+
   struct DX11Texture : public Texture
   {
     ID3D11Resource * pTexture;

--- a/src/platform_w32_dx9/Renderer.cpp
+++ b/src/platform_w32_dx9/Renderer.cpp
@@ -621,6 +621,11 @@ namespace Renderer
     pConstantTable->SetVector( pDevice, szConstName, &SetShaderConstant_VEC4 );
   }
 
+  void SetTextureFlipY(bool flipY)
+  {
+    stbi_set_flip_vertically_on_load(flipY);
+  }
+
   struct DX9Texture : public Texture
   {
     LPDIRECT3DTEXTURE9 pTexture;


### PR DESCRIPTION
Textures are shown in one way, but sampled upside down. This new feature, while wrong for advanced coders, allows newcomers to jump easier into shader coding.