### PR TITLE
Add showEditorAtStart option support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# Windows ignore
 Bonzomatic
 .obj
 tmp
@@ -5,3 +6,20 @@ build
 build.*
 .vs
 .DS_Store
+
+# Linux ignore
+bonzomatic
+*.a
+CMakeCache.txt
+/CMakeFiles*
+/external/glfw/CMakeFiles*
+/external/glfw/src/CMakeFiles*
+*.user
+Makefile
+cmake_install.cmake
+external/glfw/src/glfw3.pc
+external/glfw/src/glfw3Config.cmake
+external/glfw/src/glfw3ConfigVersion.cmake
+external/glfw/src/glfw_config.h
+
+

--- a/src/ShaderEditor.h
+++ b/src/ShaderEditor.h
@@ -93,6 +93,7 @@ struct SHADEREDITOR_OPTIONS {
   bool bVisibleWhitespace;
   AutoIndentationType eAutoIndent;
   SHADEREDITOR_THEME theme;
+  bool bShowEditorAtStart;
 };
 
 class ShaderEditor : public Scintilla::Editor

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -179,6 +179,7 @@ int main( int argc, const char *argv[] )
   editorOptions.nTabSize = 2;
   editorOptions.bVisibleWhitespace = false;
   editorOptions.eAutoIndent = aitSmart;
+  editorOptions.bShowEditorAtStart = true;
 
   int nDebugOutputHeight = 200;
   int nTexPreviewWidth = 64;
@@ -233,6 +234,8 @@ int main( int argc, const char *argv[] )
     }
     if (options.has<jsonxx::Object>("gui"))
     {
+      printf("Loading gui options...\n");
+
       if (options.get<jsonxx::Object>("gui").has<jsonxx::Number>("outputHeight"))
         nDebugOutputHeight = options.get<jsonxx::Object>("gui").get<jsonxx::Number>("outputHeight");
       if (options.get<jsonxx::Object>("gui").has<jsonxx::Number>("texturePreviewWidth"))
@@ -260,6 +263,8 @@ int main( int argc, const char *argv[] )
         fScrollXFactor = options.get<jsonxx::Object>("gui").get<jsonxx::Number>("scrollXFactor");
       if (options.get<jsonxx::Object>("gui").has<jsonxx::Number>("scrollYFactor"))
         fScrollYFactor = options.get<jsonxx::Object>("gui").get<jsonxx::Number>("scrollYFactor");
+      if (options.get<jsonxx::Object>("gui").has<jsonxx::Boolean>("showEditorAtStart"))
+        editorOptions.bShowEditorAtStart = options.get<jsonxx::Object>("gui").get<jsonxx::Boolean>("showEditorAtStart");
     }
     if (options.has<jsonxx::Object>("theme"))
     {
@@ -396,7 +401,8 @@ int main( int argc, const char *argv[] )
   static float fftDataIntegrated[FFT_SIZE];
   memset(fftDataIntegrated, 0, sizeof(float) * FFT_SIZE);
 
-  bool bShowGui = true;
+  bool bShowGui = editorOptions.bShowEditorAtStart;
+
   Timer::Start();
   float fNextTick = 0.1f;
   float fLastTimeMS = Timer::GetTime();


### PR DESCRIPTION
Easy changes for use Bonzomatic as GLSL player: it append gui-option "showEditorAtStart" for show/hide editor at start Bonzomatic. By default (without this option), Bonzomatic behavior not change, editor is visible. If showEditorAtStart set to false, Bonzomatic play shader without GUI, but GUI visible if press F11.