### PR TITLE
Fix build on arm

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -503,7 +503,7 @@ int main( int argc, const char * argv[] )
         if ( !consumed && Renderer::keyEventBuffer[ i ].character )
         {
           char    utf8[ 5 ] = { 0,0,0,0,0 };
-          wchar_t utf16[ 2 ] = { Renderer::keyEventBuffer[ i ].character, 0 };
+          wchar_t utf16[ 2 ] = { static_cast<wchar_t>(Renderer::keyEventBuffer[ i ].character), 0 };
           Scintilla::UTF8FromUTF16( utf16, 1, utf8, 4 * sizeof( char ) );
           mShaderEditor.AddCharUTF( utf8, (unsigned int) strlen( utf8 ) );
         }


### PR DESCRIPTION
This is a patch submitted to FreeBSD bygzilla by @clausecker amd it should fix build on arm.
I don't personally think it's a correct solution, as unicode handling in bonzomatic is broken anyway (#169) and the original code seem to mix UTF codepoints, wchar_t and key codes which are all different things. But it definitely doesn't make things worse and fixing the build is a good thing.