### PR TITLE
use x86_64 or arm64 on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,12 @@ if (APPLE OR WIN32)
   ############################################################################
   # MacOS
   if (APPLE)
-    set(CMAKE_OSX_ARCHITECTURES x86_64)
+    if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64")
+      set(CMAKE_OSX_ARCHITECTURES x86_64)
+    elseif (${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm64")
+      set(CMAKE_OSX_ARCHITECTURES arm64)
+    endif()
+
     set(CMAKE_FIND_FRAMEWORK LAST)
     set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++14")
     set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")


### PR DESCRIPTION
I'm on an apple "silicon" computer and I don't want to install "Rosetta" because it's crap.

With this change, depending on the architecture you'll get a x86_64 or arm64 binary, which solves "my problem".

Let me know what you think.

